### PR TITLE
Add merlin status feature

### DIFF
--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -29,7 +29,10 @@
 ###############################################################################
 
 """Updated celery configuration."""
-from __future__ import absolute_import, print_function
+from __future__ import (
+    absolute_import,
+    print_function,
+)
 
 import logging
 import os
@@ -40,7 +43,10 @@ from celery import Celery
 from celery.signals import worker_process_init
 
 import merlin.common.security.encrypt_backend_traffic
-from merlin.config import broker, results_backend
+from merlin.config import (
+    broker,
+    results_backend,
+)
 from merlin.log_formatter import FORMATS
 from merlin.router import route_for_task
 

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -33,7 +33,10 @@ SampleIndex factory methods
 """
 from parse import parse
 
-from merlin.common.sample_index import MAX_SAMPLE, SampleIndex
+from merlin.common.sample_index import (
+    MAX_SAMPLE,
+    SampleIndex,
+)
 from merlin.utils import cd
 
 

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -29,18 +29,34 @@
 ###############################################################################
 
 """Test tasks."""
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import logging
 import os
 
-from celery import chain, chord, group, shared_task, signature
-from celery.exceptions import OperationalError, TimeoutError
+from celery import (
+    chain,
+    chord,
+    group,
+    shared_task,
+    signature,
+)
+from celery.exceptions import (
+    OperationalError,
+    TimeoutError,
+)
 
 from merlin.common.abstracts.enums import ReturnCode
 from merlin.common.sample_index import uniform_directories
 from merlin.common.sample_index_factory import create_hierarchy
-from merlin.exceptions import HardFailException, InvalidChainException, RetryException
+from merlin.exceptions import (
+    HardFailException,
+    InvalidChainException,
+    RetryException,
+)
 from merlin.router import stop_workers
 from merlin.spec.expansion import (
     parameter_substitutions_for_cmd,

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -37,7 +37,10 @@ import subprocess
 from tabulate import tabulate
 
 from merlin.ascii_art import banner_small
-from merlin.config import broker, results_backend
+from merlin.config import (
+    broker,
+    results_backend,
+)
 from merlin.config.configfile import default_config_info
 
 

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -208,6 +208,17 @@ def purge_tasks(args):
 
     LOG.info(f"Purge return = {ret} .")
 
+def query_status(args):
+    """
+    CLI command for querying queue status.
+
+    :param 'args': parsed CLI arguments
+    """
+    print(banner_small)
+    filepath = verify_filepath(args.specification)
+    variables_dict = parse_override_vars(args.variables)
+    spec = get_spec_with_expansion(filepath, override_vars=variables_dict)
+    _ = router.query_status(args.task_server, spec, args.steps)
 
 def query_workers(args):
     """
@@ -461,6 +472,42 @@ def setup_argparse():
         help="Task server type from which to stop workers.\
                             Default: %(default)s",
     )
+
+    # merlin status
+    status = subparsers.add_parser(
+        "status", help="List server stats (name, number of tasks to do, \
+                              number of connected workers) for a workflow spec."
+    )
+    status.set_defaults(func=query_status)
+    status.add_argument(
+        "specification", type=str, help="Path to a Merlin YAML spec file"
+    )
+    status.add_argument(
+        "--steps",
+        nargs="+",
+        type=str,
+        dest="steps",
+        default=["all"],
+        help="The specific steps in the YAML file you want to query",
+    )
+    status.add_argument(
+        "--task_server",
+        type=str,
+        default="celery",
+        help="Task server type from which to stop workers.\
+                            Default: %(default)s",
+    )
+    status.add_argument(
+        "--vars",
+        action="store",
+        dest="variables",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
+        "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
+    )
+       
 
     # merlin info
     info = subparsers.add_parser(

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -42,10 +42,16 @@ from argparse import (
 )
 from contextlib import suppress
 
-from merlin import VERSION, router
+from merlin import (
+    VERSION,
+    router,
+)
 from merlin.ascii_art import banner_small
 from merlin.log_formatter import setup_logging
-from merlin.spec.expansion import RESERVED, get_spec_with_expansion
+from merlin.spec.expansion import (
+    RESERVED,
+    get_spec_with_expansion,
+)
 from merlin.study.study import MerlinStudy
 from merlin.utils import ARRAY_FILE_FORMATS
 
@@ -208,6 +214,7 @@ def purge_tasks(args):
 
     LOG.info(f"Purge return = {ret} .")
 
+
 def query_status(args):
     """
     CLI command for querying queue status.
@@ -219,6 +226,7 @@ def query_status(args):
     variables_dict = parse_override_vars(args.variables)
     spec = get_spec_with_expansion(filepath, override_vars=variables_dict)
     _ = router.query_status(args.task_server, spec, args.steps)
+
 
 def query_workers(args):
     """
@@ -475,8 +483,9 @@ def setup_argparse():
 
     # merlin status
     status = subparsers.add_parser(
-        "status", help="List server stats (name, number of tasks to do, \
-                              number of connected workers) for a workflow spec."
+        "status",
+        help="List server stats (name, number of tasks to do, \
+                              number of connected workers) for a workflow spec.",
     )
     status.set_defaults(func=query_status)
     status.add_argument(
@@ -507,7 +516,6 @@ def setup_argparse():
         help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
         "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
     )
-       
 
     # merlin info
     info = subparsers.add_parser(

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -42,8 +42,8 @@ from contextlib import suppress
 from merlin.study.celeryadapter import (
     create_celery_config,
     purge_celery_tasks,
-    query_celery_workers,
     query_celery_queues,
+    query_celery_workers,
     run_celery,
     start_celery_workers,
     stop_celery_workers,
@@ -109,6 +109,7 @@ def purge_tasks(task_server, spec, force, steps):
     else:
         LOG.error("Celery is not specified as the task server!")
 
+
 def query_status(task_server, spec, steps):
     """
     Queries status of queues in spec file from server.
@@ -122,10 +123,9 @@ def query_status(task_server, spec, steps):
     if task_server == "celery":
         queues = spec.make_queue_string(steps)
         # Query the queues
-        return query_celery_queues(sorted(queues.split(',')))
+        return query_celery_queues(sorted(queues.split(",")))
     else:
         LOG.error("Celery is not specified as the task server!")
-
 
 
 def query_workers(task_server):

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -43,6 +43,7 @@ from merlin.study.celeryadapter import (
     create_celery_config,
     purge_celery_tasks,
     query_celery_workers,
+    query_celery_queues,
     run_celery,
     start_celery_workers,
     stop_celery_workers,
@@ -107,6 +108,24 @@ def purge_tasks(task_server, spec, force, steps):
         return purge_celery_tasks(queues, force)
     else:
         LOG.error("Celery is not specified as the task server!")
+
+def query_status(task_server, spec, steps):
+    """
+    Queries status of queues in spec file from server.
+
+    :param `task_server`: The task server from which to purge tasks.
+    :param `spec`: A MerlinSpec object
+    :param `steps`: Spaced-separated list of stepnames to query. Default is all
+    """
+    LOG.info(f"Querying queues for steps = {steps}")
+
+    if task_server == "celery":
+        queues = spec.make_queue_string(steps)
+        # Query the queues
+        return query_celery_queues(sorted(queues.split(',')))
+    else:
+        LOG.error("Celery is not specified as the task server!")
+
 
 
 def query_workers(task_server):

--- a/merlin/spec/expansion.py
+++ b/merlin/spec/expansion.py
@@ -30,10 +30,16 @@
 
 import logging
 from collections import ChainMap
-from os.path import expanduser, expandvars
+from os.path import (
+    expanduser,
+    expandvars,
+)
 
 from merlin.common.abstracts.enums import ReturnCode
-from merlin.spec.override import dump_with_overrides, error_override_vars
+from merlin.spec.override import (
+    dump_with_overrides,
+    error_override_vars,
+)
 from merlin.spec.specification import MerlinSpec
 
 

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -141,6 +141,28 @@ def query_celery_workers():
         LOG.warning("No workers found!")
 
 
+def query_celery_queues(queues):
+    """Return stats for queues specified.
+
+    Send results to the log.
+    """
+    from merlin.celery import app
+
+    connection = app.connection()
+    found_queues = []
+    try:
+        channel = connection.channel()
+        for queue in queues:
+            try:
+                name, jobs, consumers = channel.queue_declare(queue=queue, passive=True)
+                found_queues.append((name, jobs, consumers))
+                LOG.info(f"{name:30} - Workers: {consumers:10} - Queued Tasks: {jobs:10}")
+            except:
+                LOG.warning(f"Cannot find queue {queue} on server.")
+    finally:
+        connection.close() 
+    return found_queues
+
 def get_workers(app):
     """Get all workers connected to a celery application.
 

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -37,8 +37,16 @@ import subprocess
 import time
 from contextlib import suppress
 
-from merlin.study.batch import batch_check_parallel, batch_worker_launch
-from merlin.utils import get_procs, get_yaml_var, is_running, regex_list_filter
+from merlin.study.batch import (
+    batch_check_parallel,
+    batch_worker_launch,
+)
+from merlin.utils import (
+    get_procs,
+    get_yaml_var,
+    is_running,
+    regex_list_filter,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -156,12 +164,15 @@ def query_celery_queues(queues):
             try:
                 name, jobs, consumers = channel.queue_declare(queue=queue, passive=True)
                 found_queues.append((name, jobs, consumers))
-                LOG.info(f"{name:30} - Workers: {consumers:10} - Queued Tasks: {jobs:10}")
+                LOG.info(
+                    f"{name:30} - Workers: {consumers:10} - Queued Tasks: {jobs:10}"
+                )
             except:
                 LOG.warning(f"Cannot find queue {queue} on server.")
     finally:
-        connection.close() 
+        connection.close()
     return found_queues
+
 
 def get_workers(app):
     """Get all workers connected to a celery application.

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -41,8 +41,14 @@ from maestrowf.datastructures.core import Study
 
 from merlin.common.abstracts.enums import ReturnCode
 from merlin.spec import defaults
-from merlin.spec.expansion import determine_user_variables, expand_line
-from merlin.spec.override import dump_with_overrides, error_override_vars
+from merlin.spec.expansion import (
+    determine_user_variables,
+    expand_line,
+)
+from merlin.spec.override import (
+    dump_with_overrides,
+    error_override_vars,
+)
 from merlin.spec.specification import MerlinSpec
 from merlin.study.dag import DAG
 from merlin.utils import load_array_file

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -36,7 +36,10 @@ import logging
 import os
 import re
 import subprocess
-from contextlib import contextmanager, suppress
+from contextlib import (
+    contextmanager,
+    suppress,
+)
 from copy import deepcopy
 from types import SimpleNamespace
 

--- a/tests/common/test_sample_index.py
+++ b/tests/common/test_sample_index.py
@@ -3,7 +3,10 @@ import shutil
 import unittest
 from contextlib import suppress
 
-from merlin.common.sample_index_factory import create_hierarchy, read_hierarchy
+from merlin.common.sample_index_factory import (
+    create_hierarchy,
+    read_hierarchy,
+)
 
 
 TEST_DIR = "UNIT_TEST_SPACE"

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -40,7 +40,10 @@ import time
 from contextlib import suppress
 from glob import glob
 from re import search
-from subprocess import PIPE, Popen
+from subprocess import (
+    PIPE,
+    Popen,
+)
 
 
 OUTPUT_DIR = "cli_test_studies"


### PR DESCRIPTION
Given a spec file, prints number of connected workers and tasks on queue server

```
merlin status workflows/feature_demo/feature_demo.yaml

...

[2019-12-09 16:51:14: INFO] collect_queue                  - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] default_verify_queue           - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] hello_queue                    - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] learn_queue                    - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] make_samples_queue             - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] predict_queue                  - Workers:          0 - Queued Tasks:          0
[2019-12-09 16:51:14: INFO] pyth2_hello                    - Workers:          0 - Queued Tasks:          4
[2019-12-09 16:51:14: INFO] pyth3_q                        - Workers:          0 - Queued Tasks:          1
[2019-12-09 16:51:14: INFO] stop_workers_queue             - Workers:          0 - Queued Tasks:          1
[2019-12-09 16:51:14: INFO] translate_queue                - Workers:          1 - Queued Tasks:          0

```

#25 