### PR TITLE
Feature/queue length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Development dependencies install via pip: `pip install "merlinwf[dev]"`
+- `merlin status <yaml spec>` that returns queues, number of connected
+  workers and number of unused tasks in each of those queues
 
 ### Fixed
 - `MANIFEST.in` fixes as required by Spack.

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -225,7 +225,11 @@ def query_status(args):
     filepath = verify_filepath(args.specification)
     variables_dict = parse_override_vars(args.variables)
     spec = get_spec_with_expansion(filepath, override_vars=variables_dict)
-    _ = router.query_status(args.task_server, spec, args.steps)
+    ret = router.query_status(args.task_server, spec, args.steps)
+    for name, jobs, consumers in ret:
+        print(f"{name:30} - Workers: {consumers:10} - Queued Tasks: {jobs:10}")
+    if args.csv is not None:
+        router.dump_status(ret, args.csv)
 
 
 def query_workers(args):
@@ -515,6 +519,9 @@ def setup_argparse():
         default=None,
         help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
         "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
+    )
+    status.add_argument(
+        "--csv", type=str, help="csv file to dump status report to", default=None,
     )
 
     # merlin info

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -141,7 +141,7 @@ def dump_status(query_return, csv_file):
     else:
         fmode = "w"
     with open(csv_file, mode=fmode) as f:
-        if f.mode == 'w': # add the header
+        if f.mode == "w":  # add the header
             f.write("# time")
             for name, job, consumer in query_return:
                 f.write(f",{name}:tasks,{name}:consumers")

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -121,9 +121,9 @@ def query_status(task_server, spec, steps):
     LOG.info(f"Querying queues for steps = {steps}")
 
     if task_server == "celery":
-        queues = spec.make_queue_string(steps)
+        queues = spec.get_queue_list(steps)
         # Query the queues
-        return query_celery_queues(sorted(queues.split(",")))
+        return query_celery_queues(queues)
     else:
         LOG.error("Celery is not specified as the task server!")
 

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -38,6 +38,7 @@ decoupled from the logic the tasks are running.
 import logging
 import os
 from contextlib import suppress
+from datetime import datetime
 
 from merlin.study.celeryadapter import (
     create_celery_config,
@@ -126,6 +127,27 @@ def query_status(task_server, spec, steps):
         return query_celery_queues(queues)
     else:
         LOG.error("Celery is not specified as the task server!")
+
+
+def dump_status(query_return, csv_file):
+    """
+    Dump the results of a query_status to a csv file.
+
+    :param `query_return`: The output of query_status
+    :param `csv_file`: The csv file to append
+    """
+    if os.path.exists(csv_file):
+        fmode = "a"
+    else:
+        fmode = "w"
+    with open(csv_file, mode=fmode) as f:
+        f.write("# time")
+        for name, job, consumer in query_return:
+            f.write(f",{name}:tasks,{name}:consumers")
+        f.write(f"\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        for name, job, consumer in query_return:
+            f.write(f",{job},{consumer}")
+        f.write("\n")
 
 
 def query_workers(task_server):

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -141,10 +141,12 @@ def dump_status(query_return, csv_file):
     else:
         fmode = "w"
     with open(csv_file, mode=fmode) as f:
-        f.write("# time")
-        for name, job, consumer in query_return:
-            f.write(f",{name}:tasks,{name}:consumers")
-        f.write(f"\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        if f.mode == 'w': # add the header
+            f.write("# time")
+            for name, job, consumer in query_return:
+                f.write(f",{name}:tasks,{name}:consumers")
+            f.write("\n")
+        f.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         for name, job, consumer in query_return:
             f.write(f",{job},{consumer}")
         f.write("\n")

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -176,11 +176,11 @@ class MerlinSpec(YAMLSpecification):
                 queues[step.name] = step.run["task_queue"]
         return queues
 
-    def make_queue_string(self, steps):
+    def get_queue_list(self, steps):
         """
-        Return a unique queue string for the steps
+        Return a sorted list of queues corresponding to spec steps
 
-        param steps: a list of step names
+        param steps: a list of step names or 'all'
         """
         queues = self.get_task_queues()
         if steps[0] == "all":
@@ -197,4 +197,12 @@ class MerlinSpec(YAMLSpecification):
                     f"Invalid steps '{steps}'! Try one of these (or 'all'):\n{nl.join(queues.keys())}"
                 )
                 raise
-        return ",".join(set(task_queues))
+        return sorted(set(task_queues))
+
+    def make_queue_string(self, steps):
+        """
+        Return a unique queue string for the steps
+
+        param steps: a list of step names
+        """
+        return ",".join(set(self.get_queue_list(steps)))

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -164,9 +164,7 @@ def query_celery_queues(queues):
             try:
                 name, jobs, consumers = channel.queue_declare(queue=queue, passive=True)
                 found_queues.append((name, jobs, consumers))
-                LOG.info(
-                    f"{name:30} - Workers: {consumers:10} - Queued Tasks: {jobs:10}"
-                )
+                LOG.info(f"Found queue {queue}.")
             except:
                 LOG.warning(f"Cannot find queue {queue} on server.")
     finally:


### PR DESCRIPTION
Some cosmetic changes to `merlin status`

- prints status to the screen instead of the log, so the user gets the results independent of log level
- optional --csv argument that writes the results to the csv file with the time and the results. this allows users to set up simple monitoring
