### PR TITLE
Mysql update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Updated from `mysql-connector-python-rf` to `mysql-connector-python`.
+
 ## [1.2.3] 2020-01-27
 
 ### Changed

--- a/requirements/mysql.txt
+++ b/requirements/mysql.txt
@@ -1,3 +1,3 @@
 # Packages if using MySQL.
-mysql-connector-python-rf
+mysql-connector-python
 pymysql


### PR DESCRIPTION
This is the replacement package, which will install in spack (unlike `mysql-connector-python-rf`). This is not yet tested.

EDIT: we may not even need mysql in the project anymore...