### PR TITLE
Add the --broker keyword to merlin config and config parse fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the Merlin Sphinx web docs.
+- The celery keyword is no longer required in the app.yaml file.
 
 ### Added
 - A Merlin Dockerfile and some accompanying web documentation.
+- The merlin config now takes an optional --broker argument, the
+  value can be None, default rabbitmq broker, or redis for a redis
+  local broker.
 
 ## [1.2.3] 2020-01-27
 

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -50,7 +50,10 @@ class Config:
         TODO
         """
         for field in fields:
-            setattr(self, field, nested_dict_to_namespaces(dic[field]))
+            try:
+                setattr(self, field, nested_dict_to_namespaces(dic[field]))
+            except KeyError:
+                pass
 
     def load_app(self, dic):
         """

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -157,7 +157,11 @@ def get_connection_string(include_password=True):
     `merlin.yaml` config file.
     """
     broker = CONFIG.broker.name
-    config_path = CONFIG.celery.certs
+    try:
+        config_path = CONFIG.celery.certs
+    except AttributeError:
+        config_path = None
+
 
     if broker not in BROKERS:
         raise ValueError(f"Error: {broker} is not a supported broker.")

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -162,7 +162,6 @@ def get_connection_string(include_password=True):
     except AttributeError:
         config_path = None
 
-
     if broker not in BROKERS:
         raise ValueError(f"Error: {broker} is not a supported broker.")
 

--- a/merlin/data/celery/app_redis.yaml
+++ b/merlin/data/celery/app_redis.yaml
@@ -1,10 +1,12 @@
 broker:
     # can be redis, redis+sock, or rabbitmq
-    name: rabbitmq
-    #username: # defaults to your username unless changed here
-    password: ~/.merlin/rabbit-password
+    name: redis
+
+    # username: # defaults to your username unless changed here
+    # password: ~/.merlin/rabbit-password
+    
     # server URL
-    server: jackalope.llnl.gov
+    server: localhost
 
     ### for rabbitmq, redis+sock connections ###
     #vhost: # defaults to your username unless changed here
@@ -14,22 +16,22 @@ broker:
     #path: The path to the socket.
 
     ### for redis connections ###
-    #port: The port number redis is listening on (default 6379)
-    #db_num: The data base number to connect to.
+    port: 6379
+    db_num: 0
 
 
 results_backend:
     # must be redis
     name: redis
-    dbname: mlsi
-    username: mlsi
+    # dbname: mlsi
+    # username: mlsi
     # name of file where redis password is stored.
-    password: redis.pass
-    server: jackalope.llnl.gov
+    # password: redis.pass
+    server: localhost
     # merlin will generate this key if it does not exist yet,
     # and will use it to encrypt all data over the wire to
     # your redis server.
-    encryption_key: ~/.merlin/encrypt_data_key
+    # encryption_key: ~/.merlin/encrypt_data_key
     port: 6379
     db_num: 0
 

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -279,7 +279,7 @@ def config_merlin(args):
     if output_dir is None:
         USER_HOME = os.path.expanduser("~")
         output_dir = os.path.join(USER_HOME, ".merlin")
-    _ = router.create_config(args.task_server, output_dir)
+    _ = router.create_config(args.task_server, output_dir, args.broker)
 
 
 def process_example(args):
@@ -568,6 +568,13 @@ def setup_argparse():
         default=None,
         help="Optional directory to place the default config file.\
                             Default: ~/.merlin",
+    )
+    mconfig.add_argument(
+        "--broker",
+        type=str,
+        default=None,
+        help="Optional broker type, backend will be redis\
+                            Default: rabbitmq",
     )
 
     # merlin example

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -192,7 +192,7 @@ def route_for_task(name, args, kwargs, options, task=None, **kw):
         return {"queue": queue}
 
 
-def create_config(task_server, config_dir):
+def create_config(task_server, config_dir, broker):
     """
     Create a config for the given task server.
 
@@ -206,7 +206,10 @@ def create_config(task_server, config_dir):
 
     if task_server == "celery":
         config_file = "app.yaml"
-        with resources.path("merlin.data.celery", config_file) as data_file:
+        data_config_file = "app.yaml"
+        if broker == "redis":
+            data_config_file = "app_redis.yaml"
+        with resources.path("merlin.data.celery", data_config_file) as data_file:
             create_celery_config(config_dir, config_file, data_file)
     else:
         LOG.error("Only celery can be configured currently.")


### PR DESCRIPTION
Add the --broker keyword to merlin config so a pure redis config can be used instead of the rabbitmq.
merlin config --broker redis
default is rabbitmq
Add a redis app.yaml file.
Remove the requirement for celery keyword in the app.yaml config file.