### PR TITLE
changed python and pip to v3 in merlin info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the Merlin Sphinx web docs.
 - Changed the example workflows to use python3 instead of python.
+- Updated `merlin info` to lookup python3 and and pip3.
 
 ### Added
 - cli test flag `--local`, which can be used in place of listing out the id of each

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -97,7 +97,7 @@ def print_info(args):
     print("Python Configuration")
     print("-" * 25)
     print("")
-    info_calls = ["which python", "python --version", "which pip", "pip --version"]
+    info_calls = ["which python3", "python3 --version", "which pip3", "pip3 --version"]
     info_str = ""
     for x in info_calls:
         info_str += 'echo " $ ' + x + '" && ' + x + "\n"

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -552,7 +552,7 @@ def setup_argparse():
 
     # merlin info
     info = subparsers.add_parser(
-        "info", help="show pip and python versions and locations"
+        "info", help="display info about the merlin configuration and the python configuration. Useful for debugging."
     )
     info.set_defaults(func=print_info)
 

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -552,7 +552,8 @@ def setup_argparse():
 
     # merlin info
     info = subparsers.add_parser(
-        "info", help="display info about the merlin configuration and the python configuration. Useful for debugging."
+        "info",
+        help="display info about the merlin configuration and the python configuration. Useful for debugging.",
     )
     info.set_defaults(func=print_info)
 


### PR DESCRIPTION
Addresses issue $124

```
Merlin Configuration
-------------------------

 config_file        | /Users/bay1/.merlin/app.yaml
 is_debug           | False
 merlin_home        | /Users/bay1/.merlin
 merlin_home_exists | True
 broker             | No broker configured.
 backend            | redis://mlsi:******@jackalope.llnl.gov:6379/0

Python Configuration
-------------------------

 $ which python3
/Users/bay1/merlin/venv_merlin_py3_7/bin/python3

 $ python3 --version
Python 3.7.5

 $ which pip3
/Users/bay1/merlin/venv_merlin_py3_7/bin/pip3

 $ pip3 --version
pip 20.0.2 from /Users/bay1/merlin/venv_merlin_py3_7/lib/python3.7/site-packages/pip (python 3.7)

"echo $PYTHONPATH"

```