### PR TITLE
corner case bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Bug that prevented `OUTPUT_PATH` from being and integer.
+
 ## [1.4.1] [2020-03-06]
 
 ### Changed

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -274,12 +274,12 @@ class MerlinStudy:
             return os.path.abspath(output_path)
 
         else:
-            output_path = self.spec.output_path
+            output_path = str(self.spec.output_path)
 
             if (self.override_vars is not None) and (
                 "OUTPUT_PATH" in self.override_vars
             ):
-                output_path = self.override_vars["OUTPUT_PATH"]
+                output_path = str(self.override_vars["OUTPUT_PATH"])
 
             output_path = expand_line(output_path, self.user_vars)
             output_path = os.path.abspath(output_path)


### PR DESCRIPTION
This allows `OUTPUT_PATH` to be an integer, which previously broke merlin.