### PR TITLE
Feature/luc/zfill dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional ssl files for the broker and results backend config.
 - A url keyword in the app.yaml file to override the entire broker or results backend configuration.
 - The `all` option to `batch.nodes`.
+- Auto zero-padding of sample directories, e.g. 00/00, 00/01 .. 10/10
 
 ### Fixed
 - Bug that prevented an empty username for results backend and broker when using redis.
 - Bug that prevented `OUTPUT_PATH` from being an integer.
+- Bug that always had sample directory tree start with "0"
 
 ### Changed
 - Updated docs from `pip3 install merlinwf` to `pip3 install merlin`.

--- a/merlin/common/sample_index.py
+++ b/merlin/common/sample_index.py
@@ -50,9 +50,11 @@ def new_dir(path):
 
 def uniform_directories(num_samples=MAX_SAMPLE, bundle_size=1, level_max_dirs=100):
     """Create a directory hierarchy uniformly stepping up directory sizes."""
-    directory_sizes = [bundle_size * level_max_dirs]
+    directory_sizes = [bundle_size]
     while directory_sizes[0] < num_samples:
         directory_sizes.insert(0, directory_sizes[0] * level_max_dirs)
+    # We've gone over the total number of samples, remove the first entry
+    del(directory_sizes[0])
     return directory_sizes
 
 

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -48,6 +48,7 @@ def create_hierarchy(
     start_sample_id=0,
     start_bundle_id=0,
     address="",
+    n_digits=1,
 ):
     """
     SampleIndex Hierarchy Factory method. Wraps
@@ -60,6 +61,7 @@ def create_hierarchy(
         for - a list, one value for each level in the directory hierarchy.
     :root: The root path of this index. Defaults to ".".
     :start_sample_id: The start of the sample count. Defaults to 0.
+    :n_digits: The number of digits to pad the directories with
     """
     if directory_sizes is None:
         directory_sizes = []
@@ -71,6 +73,7 @@ def create_hierarchy(
         start_bundle_id=start_bundle_id,
         min_sample=start_sample_id,
         address=address,
+        n_digits=n_digits,
     )
 
 
@@ -82,6 +85,7 @@ def create_hierarchy_from_max_sample(
     start_bundle_id=0,
     min_sample=0,
     address="",
+    n_digits=1,
 ):
     """"
     Construct the SampleIndex based off the total number of samples and the
@@ -96,6 +100,7 @@ def create_hierarchy_from_max_sample(
         for - a list, one value for each level in the directory hierarchy.
     :bundle_id: The current bundle_id count.
     :min_sample: The start of the sample count.
+    :n_digits: The number of digits to pad the directories with
     """
     if directory_sizes is None:
         directory_sizes = []
@@ -117,7 +122,9 @@ def create_hierarchy_from_max_sample(
     for i in range(min_sample, max_sample, num_samples_per_child):
         child_min_sample_id = i
         child_max_sample_id = min(i + num_samples_per_child, max_sample)
-        child_address = address_prefix + f"{child_id}"
+
+        child_dir = f"{child_id}".zfill(n_digits)
+        child_address = address_prefix + child_dir
 
         if directory_sizes:
             # Append an SampleIndex sub-hierarchy child.
@@ -125,10 +132,11 @@ def create_hierarchy_from_max_sample(
                 child_max_sample_id,
                 bundle_size,
                 directory_sizes[1:],
-                root=f"{child_id}",
+                root=child_dir,
                 min_sample=child_min_sample_id,
                 start_bundle_id=bundle_id,
                 address=child_address,
+                n_digits=n_digits,
             )
 
             bundle_id += children[child_address].num_bundles

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -411,12 +411,13 @@ def expand_tasks_with_samples(
     directory_sizes = uniform_directories(
         len(samples), bundle_size=1, level_max_dirs=level_max_dirs
     )
-    directory_sizes.append(1)
+
     glob_path = "*/" * len(directory_sizes)
 
     # Write a hierarchy to get the all paths string
     sample_index = create_hierarchy(
-        len(samples), bundle_size=1, directory_sizes=directory_sizes, root=""
+        len(samples), bundle_size=1, directory_sizes=directory_sizes, root="",
+        n_digits=len(str(level_max_dirs))
     )
     sample_paths = sample_index.make_directory_string()
 


### PR DESCRIPTION
This addresses #173 

Also fixed the bug whereby top level of directory hierarchy was always "0"

@ben-bay We will need to change the diagrams of directory structures for the hello world tutorial example, since the superfluous top layer will be gone. Also, Peter has removed the sample_index.txt file, which we don't need, so that'll need to be modded too