### PR TITLE
unrecognized key warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This can be used at the end of a batch submission script to keep the
   allocation alive while workers are present.  
 - The ~/.merlin dir will be searched for the results password. 
+- A warning whenever an unrecognized key is found in a Merlin spec; this may
+  help users find small mistakes due to spelling or indentation more quickly.
 
 ### Fixed
 - Bug that prevented an empty username for results backend and broker when using redis.

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -87,7 +87,7 @@ def get_backend_password(password_file, certs_path=None):
     password = None
 
     mer_pass = os.path.join(os.path.expanduser("~/.merlin"), password_file)
-    password_file = os.path.expanduser(password_file)   
+    password_file = os.path.expanduser(password_file)
 
     password_filepath = ""
     if os.path.exists(mer_pass):

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory
+# Written by the Merlin dev team, listed in the CONTRIBUTORS file.
+# <merlin@llnl.gov>
+#
+# LLNL-CODE-797170
+# All rights reserved.
+# This file is part of Merlin, Version: 1.4.1.
+#
+# For details, see https://github.com/LLNL/merlin.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+###############################################################################
+
+DESCRIPTION = {"description": {}}
+
+BATCH = {"batch": {"type", "bank", "queue", "dry_run", "shell", "flux_path", "flux_start_opts", "flux_exec_workers", "launch_pre", "launch_args", "worker_launch", "nodes"}}
+
+ENV = {"env": {"variables": {}}}
+
+STUDY_STEP = {"name", "description", "run"}
+
+STUDY_STEP_RUN = {"cmd", "restart", "task_queue", "shell", "max_retries", "depends", "nodes", "procs", "cores per node", "batch"}
+
+PARAMETER = {"global.parameters"}
+
+SINGLE_PARAMETER = {"values", "label"}
+
+MERLIN = {
+    "merlin": {
+        "resources": {"task_server", "overlap", "workers"},
+        "samples": None,
+    }
+}
+
+WORKER = {"steps", "nodes", "batch", "args", "machines"}
+
+SAMPLES = {
+    "generate": {"cmd"},
+    "level_max_dirs",
+}

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -28,30 +28,27 @@
 # SOFTWARE.
 ###############################################################################
 
-DESCRIPTION = {"description": {}}
+DESCRIPTION = {"description", "name"}
 
-BATCH = {"batch": {"type", "bank", "queue", "dry_run", "shell", "flux_path", "flux_start_opts", "flux_exec_workers", "launch_pre", "launch_args", "worker_launch", "nodes"}}
+BATCH = {"type", "bank", "queue", "dry_run", "shell", "flux_path", "flux_start_opts", "flux_exec_workers", "launch_pre", "launch_args", "worker_launch", "nodes"}
 
-ENV = {"env": {"variables": {}}}
+ENV = {"variables", "labels"}
 
 STUDY_STEP = {"name", "description", "run"}
 
 STUDY_STEP_RUN = {"cmd", "restart", "task_queue", "shell", "max_retries", "depends", "nodes", "procs", "cores per node", "batch"}
 
-PARAMETER = {"global.parameters"}
+PARAMETER = {"values", "label"}
 
-SINGLE_PARAMETER = {"values", "label"}
+MERLIN_RESOURCES = {"task_server", "overlap", "workers"}
 
-MERLIN = {
-    "merlin": {
-        "resources": {"task_server", "overlap", "workers"},
-        "samples": None,
-    }
-}
+MERLIN = {"resources", "samples"}
 
 WORKER = {"steps", "nodes", "batch", "args", "machines"}
 
 SAMPLES = {
-    "generate": {"cmd"},
+    "generate",
     "level_max_dirs",
+    "file",
+    "column_labels"
 }

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -30,13 +30,37 @@
 
 DESCRIPTION = {"description", "name"}
 
-BATCH = {"type", "bank", "queue", "dry_run", "shell", "flux_path", "flux_start_opts", "flux_exec_workers", "launch_pre", "launch_args", "worker_launch", "nodes"}
+BATCH = {
+    "type",
+    "bank",
+    "queue",
+    "dry_run",
+    "shell",
+    "flux_path",
+    "flux_start_opts",
+    "flux_exec_workers",
+    "launch_pre",
+    "launch_args",
+    "worker_launch",
+    "nodes",
+}
 
 ENV = {"variables", "labels"}
 
 STUDY_STEP = {"name", "description", "run"}
 
-STUDY_STEP_RUN = {"cmd", "restart", "task_queue", "shell", "max_retries", "depends", "nodes", "procs", "cores per node", "batch"}
+STUDY_STEP_RUN = {
+    "cmd",
+    "restart",
+    "task_queue",
+    "shell",
+    "max_retries",
+    "depends",
+    "nodes",
+    "procs",
+    "cores per node",
+    "batch",
+}
 
 PARAMETER = {"values", "label"}
 
@@ -46,9 +70,4 @@ MERLIN = {"resources", "samples"}
 
 WORKER = {"steps", "nodes", "batch", "args", "machines"}
 
-SAMPLES = {
-    "generate",
-    "level_max_dirs",
-    "file",
-    "column_labels"
-}
+SAMPLES = {"generate", "level_max_dirs", "file", "column_labels"}

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -45,7 +45,7 @@ BATCH = {
     "nodes",
 }
 
-ENV = {"variables", "labels"}
+ENV = {"variables", "labels", "sources", "dependencies"}
 
 STUDY_STEP = {"name", "description", "run"}
 
@@ -58,8 +58,17 @@ STUDY_STEP_RUN = {
     "depends",
     "nodes",
     "procs",
-    "cores per node",
+    "cores per task",
+    "gpus per task",
     "batch",
+    "slurm",
+    "lsf",
+    "bind",
+    "num resource set",
+    "launch_distribution",
+    "exit_on_error",
+    "flux",
+    "walltime",
 }
 
 PARAMETER = {"values", "label"}

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -144,6 +144,9 @@ class MerlinSpec(YAMLSpecification):
 
         recurse(object_to_update, default_dict)
 
+    def warn_unrecognized_keys():
+        pass
+
     def dump(self):
         """
         Dump this MerlinSpec to a yaml string.

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -40,7 +40,10 @@ from io import StringIO
 import yaml
 from maestrowf.datastructures import YAMLSpecification
 
-from merlin.spec import all_keys, defaults
+from merlin.spec import (
+    all_keys,
+    defaults,
+)
 
 
 def represent_none(self, _):
@@ -93,7 +96,7 @@ class MerlinSpec(YAMLSpecification):
         spec.merlin = MerlinSpec.load_merlin_block(StringIO(string))
         spec.specroot = None
         spec.process_spec_defaults()
-        #spec.warn_unrecognized_keys()
+        # spec.warn_unrecognized_keys()
         return spec
 
     @staticmethod
@@ -164,21 +167,31 @@ class MerlinSpec(YAMLSpecification):
         # check steps
         for step in self.study:
             MerlinSpec.check_section(step["name"], step, all_keys.STUDY_STEP)
-            MerlinSpec.check_section(step["name"]+".run", step["run"], all_keys.STUDY_STEP_RUN)
+            MerlinSpec.check_section(
+                step["name"] + ".run", step["run"], all_keys.STUDY_STEP_RUN
+            )
 
         # check merlin
         MerlinSpec.check_section("merlin", self.merlin, all_keys.MERLIN)
-        MerlinSpec.check_section("merlin.resources", self.merlin["resources"], all_keys.MERLIN_RESOURCES)
+        MerlinSpec.check_section(
+            "merlin.resources", self.merlin["resources"], all_keys.MERLIN_RESOURCES
+        )
         for worker, contents in self.merlin["resources"]["workers"].items():
-            MerlinSpec.check_section("merlin.resources.workers "+worker, contents, all_keys.WORKER)
+            MerlinSpec.check_section(
+                "merlin.resources.workers " + worker, contents, all_keys.WORKER
+            )
         if self.merlin["samples"]:
-            MerlinSpec.check_section("merlin.samples", self.merlin["samples"], all_keys.SAMPLES)
-        
+            MerlinSpec.check_section(
+                "merlin.samples", self.merlin["samples"], all_keys.SAMPLES
+            )
+
     @staticmethod
     def check_section(section_name, section, all_keys):
         diff = set(section.keys()).difference(all_keys)
         for extra in diff:
-            LOG.warn(f"Unrecognized key '{extra}' found in spec section '{section_name}'.")
+            LOG.warn(
+                f"Unrecognized key '{extra}' found in spec section '{section_name}'."
+            )
 
     def dump(self):
         """

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -349,7 +349,7 @@ class MerlinStudy:
         if self.restart_dir is None:
             self.write_expanded_spec(self.expanded_filepath)
 
-        return MerlinSpec.load_specification(self.expanded_filepath)
+        return MerlinSpec.load_specification(self.expanded_filepath, suppress_warning=False)
 
     @cached_property
     def flux_command(self):

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -349,7 +349,9 @@ class MerlinStudy:
         if self.restart_dir is None:
             self.write_expanded_spec(self.expanded_filepath)
 
-        return MerlinSpec.load_specification(self.expanded_filepath, suppress_warning=False)
+        return MerlinSpec.load_specification(
+            self.expanded_filepath, suppress_warning=False
+        )
 
     @cached_property
     def flux_command(self):


### PR DESCRIPTION
This will save users (and me, frankly) lots of headache due to slight misspellings or indentation errors.

Merlin still allows extra keys; but since they are never used, it will be helpful to show a warning whenever one is found.

Have I missed any keys that merlin supports?