### PR TITLE
Library/Req Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The first version of an optimization workflow, which can be accessed with
   `merlin example optimization`.
+- Dev requirement library for finding dependencies (and `make reqlist` target)
 
 ### Changed
 - Improved warning and help messages about `no_errors`
+
+### Fixed
+- Pinned to celery>5.0.3 so that `merlin purge` works again
 
 ## [1.7.5]
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ PENV=merlin$(PYV)
 .PHONY : check-style
 .PHONY : check-camel-case
 .PHONY : checks
+.PHONY : reqlist
 
 
 all: install-dev install-merlin install-workflow-deps
@@ -172,3 +173,6 @@ version:
 	find tests/ -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
 	find Makefile -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
 
+# Make a list of all dependencies/requirements
+reqlist:
+	johnnydep merlin --output-format pinned

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,3 +7,4 @@ pytest
 twine
 sphinx>=2.0.0
 alabaster
+johnnydep

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,5 +1,5 @@
 cached_property
-celery[redis,sqlalchemy]>=5.0.0
+celery[redis,sqlalchemy]>=5.0.3
 coloredlogs
 cryptography
 importlib_resources; python_version < '3.7'


### PR DESCRIPTION
- Pin to updated celery with fix to queue purging
- Add `johnnydep` to dev reqs, a package that lets us find and list all dependencies
  - New `make reqlist` target