### PR TITLE
fixed example display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Bug that caused example workflows with a variable reference in their
+  name to be listed by `merlin example list` with variable reference notation.
+
 ## [1.7.6]
 
 ### Added

--- a/merlin/examples/generator.py
+++ b/merlin/examples/generator.py
@@ -89,7 +89,13 @@ def list_examples():
                     continue
                 except TypeError:
                     continue
-            rows.append([spec_metadata["name"], spec_metadata["description"]])
+            name = spec_metadata["name"]
+            if name is None:
+                continue
+            # if there is a variable reference in the workflow name, instead list the filename (minus the yaml extension).
+            if "$" in name:
+                name = os.path.basename(os.path.normpath(spec)).replace(".yaml", "")
+            rows.append([name, spec_metadata["description"]])
     return "\n" + tabulate.tabulate(rows, headers) + "\n"
 
 


### PR DESCRIPTION
`feature_demo` used to display as `$(NAME)`. Now it displays as `feature_demo` when `merlin example list` is used. This extends to any wf example with variables in-name.