### PR TITLE
Retry Delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `retry_delay` field in a step to specify a countdown in seconds prior to running a
+  restart or retry
+
 ## [1.7.9]
 
 ### Fixed

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -138,7 +138,17 @@ The max number of retries in given step can be specified with the ``max_retries`
 
 Alternatively, use ``exit $(MERLIN_RESTART)`` to run the optional ``<step>.run.restart`` section.
 
+To delay a retry or restart directive, add the ``retry_delay`` field.
+
 To restart failed steps after a workflow is done running, see :ref:`restart`.
+
+
+My code quits early but needs a restart. Can I delay the restart until the batch job ends?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Yes. Add the ``retry_delay`` field to the step. This specifies how many seconds before the task
+gets run after the restart. Set this value to large enough for your problem to finish.
+
+See the ``merlin example restart_delay`` example for syntax.
 
 
 How do I mark a step failure?
@@ -179,6 +189,7 @@ Also under ``run``, the following fields are optional:
         task_queue: <task queue name for this step>
         shell: <e.g., /bin/bash, /usr/bin/env python3>
         max_retries: <integer>
+        retry_delay: <integer: seconds>
         nodes: <integer>
         procs: <integer>
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -138,18 +138,42 @@ The max number of retries in given step can be specified with the ``max_retries`
 
 Alternatively, use ``exit $(MERLIN_RESTART)`` to run the optional ``<step>.run.restart`` section.
 
-To delay a retry or restart directive, add the ``retry_delay`` field.
+To delay a retry or restart directive, add the ``retry_delay`` field to the step.
+Note: ``retry_delay`` only works in server mode (ie not ``--local`` mode).
 
 To restart failed steps after a workflow is done running, see :ref:`restart`.
 
 
-My code quits early but needs a restart. Can I delay the restart until the batch job ends?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Yes. Add the ``retry_delay`` field to the step. This specifies how many seconds before the task
+How do I put a time delay in before a restart or retry?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Add the ``retry_delay`` field to the step. This specifies how many seconds before the task
 gets run after the restart. Set this value to large enough for your problem to finish.
 
 See the ``merlin example restart_delay`` example for syntax.
 
+Note: ``retry_delay`` only works in server mode (ie not ``--local`` mode).
+
+I have a long running batch task that needs to restart, what should I do?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Before your allocation ends, use ``$(MERLIN_RESTART)`` or ``$(MERLIN_RETRY)`` but
+with a ``retry_delay`` on your step for longer that your allocation has left.
+The server will hold onto the step for that long (in seconds) before releasing it,
+allowing your batch allocation to end without the worker grabbing the step right away.
+
+For instance, your step could look something like this
+
+.. code:: yaml
+
+    name: batch_task
+    description: A long running task that needs to restart
+    run:
+        cmd: |
+            # Run my code, but end 60 seconds before my allocation
+            my_code --end_early 60s
+            if [ -e restart_needed_flag ]; then
+                exit $(MERLIN_RESTART)
+            fi
+        retry_delay: 120 # wait at least 2 minutes before restarting 
 
 How do I mark a step failure?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/merlin_specification.rst
+++ b/docs/source/merlin_specification.rst
@@ -169,7 +169,7 @@ see :doc:`./merlin_variables`.
         procs: 1
         task_queue: lqueue
         max_retries: 3    # maximum number of retries
-        retry_delay: 10   # delay in seconds before retry gets executed
+        retry_delay: 10   # delay retry for N seconds (default 1)
         batch:
           type: <override the default batch type>
 

--- a/docs/source/merlin_specification.rst
+++ b/docs/source/merlin_specification.rst
@@ -168,6 +168,8 @@ see :doc:`./merlin_variables`.
         nodes: 1
         procs: 1
         task_queue: lqueue
+        max_retries: 3    # maximum number of retries
+        retry_delay: 10   # delay in seconds before retry gets executed
         batch:
           type: <override the default batch type>
 

--- a/docs/source/merlin_variables.rst
+++ b/docs/source/merlin_variables.rst
@@ -176,7 +176,10 @@ Step return variables
 
    * - ``$(MERLIN_RESTART)``
      - Run this step's ``restart`` command, or re-run ``cmd`` if ``restart``
-       is absent.
+       is absent. The default maximum number of retries+restarts for any given step
+       is 30. You can override this by adding a ``max_retries`` field under the run
+       field in the specification. Issues a warning. Default will retry in 1 second.
+       To override the delay time, specify ``retry_delay``.
      -
        ::
 
@@ -187,11 +190,14 @@ Step return variables
                exit $(MERLIN_RESTART)
             restart: |
                echo "bye, mom!" >> my_file.txt
+            max_retries: 23
+            retry_delay: 10
 
    * - ``$(MERLIN_RETRY)``
      - Retry this step's ``cmd`` command. The default maximum number of retries for any given step
        is 30. You can override this by adding a ``max_retries`` field under the run
-       field in the specification. Issues a warning.
+       field in the specification. Issues a warning. Default will retry in 1 second. To override
+       the delay time, specify retry_delay.
      - ::
 
           run:
@@ -200,6 +206,7 @@ Step return variables
                echo "hi mom!" >> my_file.txt
                exit $(MERLIN_RETRY)
             max_retries: 23
+            retry_delay: 10
 
    * - ``$(MERLIN_SOFT_FAIL)``
      - Mark this step as a failure, note in the warning log but keep going.

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -118,7 +118,7 @@ def merlin_step(self, *args, **kwargs):
                 LOG.info(
                     f"Step '{step_name}' in '{step_dir}' is being restarted ({self.request.retries + 1}/{self.max_retries})..."
                 )
-                self.retry()
+                self.retry(countdown = step.retry_delay)
             except MaxRetriesExceededError:
                 LOG.warning(
                     f"*** Step '{step_name}' in '{step_dir}' exited with a MERLIN_RESTART command, but has already reached its retry limit ({self.max_retries}). Continuing with workflow."
@@ -130,7 +130,7 @@ def merlin_step(self, *args, **kwargs):
                 LOG.info(
                     f"Step '{step_name}' in '{step_dir}' is being retried ({self.request.retries + 1}/{self.max_retries})..."
                 )
-                self.retry()
+                self.retry(countdown = step.retry_delay)
             except MaxRetriesExceededError:
                 LOG.warning(
                     f"*** Step '{step_name}' in '{step_dir}' exited with a MERLIN_RETRY command, but has already reached its retry limit ({self.max_retries}). Continuing with workflow."

--- a/merlin/examples/workflows/restart_delay/restart_delay.yaml
+++ b/merlin/examples/workflows/restart_delay/restart_delay.yaml
@@ -1,0 +1,99 @@
+description:
+  description: A simple ensemble of with restart delay times.
+  name: restart_delay
+
+batch:
+  type: local
+
+env:
+  variables:
+    OUTPUT_PATH: ./studies
+    N_SAMPLES: 10
+    STAMP_TIME: touch timings.txt; date +"%r" >> timings.txt
+
+study:
+- description: Build the code
+  name: build
+  run:
+    cmd: echo mpicc -o mpi_hello $(SPECROOT)/scripts/hello.c
+    task_queue: trs_par
+- description: Echo the params
+  name: run_10 
+  run:
+    cmd: |
+      $(STAMP_TIME)
+      if [ -e restarted ]; then
+        exit $(MERLIN_SUCCESS)
+      fi
+      echo $(build.workspace)/mpi_hello $(V1) $(V2)
+      # This is to test the re-run of cmd if no restart is given
+      touch restarted
+      exit $(MERLIN_RESTART)
+    depends: [build]
+    task_queue: trs_par
+    nodes: 1
+    procs: 4
+    cores per task: 1
+    retry_delay: 10
+- description: Echo the params
+  name: runs_rt_30 
+  run:
+    cmd: |
+      $(STAMP_TIME)
+      if [ -e retried ]; then
+        exit $(MERLIN_SUCCESS)
+      fi
+      echo $(build.workspace)/mpi_hello $(V1) $(V2)
+      touch retried
+      # This is to test the re-run of cmd if no restart is given
+      exit $(MERLIN_RETRY)
+    depends: [build]
+    task_queue: trs_par
+    nodes: 1
+    procs: 4
+    cores per task: 1
+    retry_delay: 30
+- description: Echo the params using restart
+  name: runs_rs_1 
+  run:
+    cmd: |
+      $(STAMP_TIME)
+      echo ln -s $(build.workspace)/mpi_hello .
+      exit $(MERLIN_RESTART)
+    depends: [build]
+    task_queue: trs_par
+    nodes: 1
+    procs: 4
+    cores per task: 1
+    restart: |
+       $(STAMP_TIME)
+       echo $(build.workspace)/mpi_hello $(V1) $(V2)
+       exit $(MERLIN_SUCCESS)
+
+- description: Dump flux info
+  name: data
+  run:
+    cmd: |
+      $(STAMP_TIME)
+      echo flux kvs dir lwj.0.0.5 >& trs_kvs.out
+    depends: [run_10*, runs_rs_1*, runs_rt_30*]
+    task_queue: trs_par
+
+global.parameters:
+  STUDY:
+    label: STUDY.%%
+    values:
+    - FLUXTEST
+
+merlin:
+  resources:
+    task_server: celery
+    workers:
+      simworkers:
+        args: -l INFO --prefetch-multiplier 1 -Ofair
+        steps: [all]
+  samples:
+    column_labels: [V1, V2]
+    file: $(MERLIN_INFO)/samples.npy
+    generate:
+      cmd: python3 $(SPECROOT)/scripts/make_samples.py -dims 2 -n $(N_SAMPLES) -outfile=$(MERLIN_INFO)/samples.npy 

--- a/merlin/examples/workflows/restart_delay/scripts/make_samples.py
+++ b/merlin/examples/workflows/restart_delay/scripts/make_samples.py
@@ -1,0 +1,61 @@
+import argparse
+import ast
+import sys
+
+import numpy as np
+
+from merlin.common.util_sampling import scale_samples
+
+
+def process_args(args):
+    n_samples = args.n
+    n_dims = args.dims
+    sample_type = args.sample_type
+    if sample_type == "random":
+        x = np.random.random((n_samples, n_dims))
+    elif sample_type == "grid":
+        subdivision = int(pow(n_samples, 1 / float(n_dims)))
+        temp = [np.linspace(0, 1.0, subdivision) for i in range(n_dims)]
+        X = np.meshgrid(*temp)
+        x = np.stack([xx.flatten() for xx in X], axis=1)
+
+    if args.scale is not None:
+        limits = []
+        do_log = []
+        scales = ast.literal_eval(args.scale)
+        for scale in scales:
+            limits.append((scale[0], scale[1]))
+            if scale[2] == "log":
+                do_log.append(True)
+            else:
+                do_log.append(False)
+        x = scale_samples(x, limits, do_log=do_log)
+
+    np.save(args.outfile, x)
+
+
+def setup_argparse():
+    parser = argparse.ArgumentParser("Generate some samples!")
+    parser.add_argument("-n", help="number of samples", default=100, type=int)
+    parser.add_argument("-dims", help="number of dimensions", default=2, type=int)
+    parser.add_argument(
+        "-sample_type",
+        help="type of sampling. options: random, grid. If grid, will try to get close to the correct number of samples",
+        default="random",
+    )
+    parser.add_argument(
+        "-scale",
+        help='ranges to scale results in form "[(min,max,type),(min, max,type)]" where type = "linear" or "log"',
+    )
+    parser.add_argument("-outfile", help="name of output .npy file", default="samples")
+    return parser
+
+
+def main():
+    parser = setup_argparse()
+    args = parser.parse_args()
+    process_args(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -88,6 +88,7 @@ class MerlinLSFScriptAdapter(SlurmScriptAdapter):
             "restart",
             "task_queue",
             "max_retries",
+            "retry_delay",
             "pre",
             "post",
             "depends",
@@ -175,6 +176,7 @@ class MerlinSlurmScriptAdapter(SlurmScriptAdapter):
         new_unsupported = [
             "task_queue",
             "max_retries",
+            "retry_delay",
             "pre",
             "post",
             "gpus per task",
@@ -307,6 +309,7 @@ class MerlinFluxScriptAdapter(MerlinSlurmScriptAdapter):
             "restart",
             "task_queue",
             "max_retries",
+            "retry_delay",
             "pre",
             "post",
             "depends",

--- a/merlin/study/step.py
+++ b/merlin/study/step.py
@@ -148,6 +148,11 @@ class Step:
         return "merlin"
 
     @property
+    def retry_delay(self):
+        default_retry_delay = 1
+        return self.mstep.step.__dict__["run"].get("retry_delay", default_retry_delay)
+
+    @property
     def max_retries(self):
         """
         Returns the max number of retries for this step.


### PR DESCRIPTION
Addresses #58 #75 #76 

Add the ``retry_delay`` field to specify a step's delay in seconds when calling a MERLIN_RESTART or MERLIN_RETRY
This enables long-running batch jobs that end early to avoid grabbing the task right away.

New example ``merlin example restart_delay`` shows how to use it. Docs updated as well.

Note: does not work in --local mode. Unclear how to enable this (if possible), since local implies eager, which means tasks are run right away. ``retry_delay`` holds the task on the server for the specified number of seconds.
