### PR TITLE
Remove --mpi=none default arg for srun launch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `feature_demo` now uses `merlin-spellbook` instead of its own scripts.
+- Remove the --mpi=none run default launch argument. This can be added by 
+  setting the launch_args argument in the batch section in the spec.
 
 ## [1.7.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `feature_demo` now uses `merlin-spellbook` instead of its own scripts.
-- Remove the --mpi=none run default launch argument. This can be added by 
+- Remove the --mpi=none srun default launch argument. This can be added by 
   setting the launch_args argument in the batch section in the spec.
 
 ## [1.7.9]

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -359,7 +359,7 @@ More information can be found at the `Flux web page <http://flux-framework.org/d
 
 Older versions of flux may need the ``--mpi=none`` argument if flux is 
 launched on a system using the SLURM scheduler. This argument can be added
-in the ``launch_args`` ariable in the batch section.
+in the ``launch_args`` variable in the batch section.
 
 .. code:: yaml
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -356,6 +356,17 @@ to specify the same launch command that will work on different HPC clusters with
 default schedulers such as SLURM or LSF.
 More information can be found at the `Flux web page <http://flux-framework.org/docs/home/>`_.
 
+
+Older versions of flux may need the ``--mpi=none`` argument if flux is 
+launched on a system using the SLURM scheduler. This argument can be added
+in the ``launch_args`` ariable in the batch section.
+
+.. code:: yaml
+
+   batch:
+     type: flux
+     launch_args: --mpi=none
+
 How do I use flux on LC?
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The ``--mpibind=off`` option is currently required when using flux with a slurm launcher

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -160,7 +160,7 @@ def batch_worker_launch(spec, com, nodes=None, batch=None):
     launchs = worker_launch
     if not launchs:
         if btype == "slurm" or launcher == "slurm":
-            launchs = f"srun --mpi=none -N {nodes} -n {nodes}"
+            launchs = f"srun -N {nodes} -n {nodes}"
             if bank:
                 launchs += f" -A {bank}"
             if queue:


### PR DESCRIPTION
Remove the --mpi=none run default launch argument. This can be added by
setting the launch_args argument in the batch section in the spec.