### PR TITLE
Explictly wrap queue name string in quotes to make it more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Explictly wrap queue string in quotes for robustness
+
 ## [1.8.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-- Explictly wrap queue string in quotes for robustness
 
 ## [1.8.0]
 
@@ -34,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scalability and server stability.
 - Flake8 examination slightly modified for more generous cyclomatic complexity.
 	- Certain tests and source code have been refactored to abide by Flake8 conventions.
+
+### Fixed
+- Explictly wrap queue string in quotes for robustness
 
 ## [1.7.9]
 

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -367,7 +367,8 @@ class MerlinSpec(YAMLSpecification):
 
         param steps: a list of step names
         """
-        return ",".join(set(self.get_queue_list(steps)))
+        queues = ",".join(set(self.get_queue_list(steps)))
+        return f"\"{queues}\""
 
     def get_worker_names(self):
         result = []


### PR DESCRIPTION
Addresses #319 by wrapping the queue names in quotes.