### PR TITLE
Re-added support for all brokers with task priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.8.1]
+
+### Fixed
+- task priority support for amqp, amqps, rediss, redis+socket brokers
 
 ## [1.8.0]
 

--- a/merlin/config/utils.py
+++ b/merlin/config/utils.py
@@ -8,6 +8,11 @@ class Priority(enum.Enum):
     mid = 2
     low = 3
 
+def is_rabbit_broker(broker):
+    return broker in ["rabbitmq", "amqps", "amqp"]
+
+def is_redis_broker(broker):
+    return broker in ["redis", "rediss", "redis+socket"]
 
 def get_priority(priority):
     broker = CONFIG.broker.name.lower()
@@ -18,16 +23,16 @@ def get_priority(priority):
         )
     if priority == Priority.mid:
         return 5
-    if broker == "rabbitmq":
+    if is_rabbit_broker(broker):
         if priority == Priority.low:
             return 1
         if priority == Priority.high:
             return 10
-    if broker == "redis":
+    if is_redis_broker(broker):
         if priority == Priority.low:
             return 10
         if priority == Priority.high:
             return 1
     raise ValueError(
-        "Function get_priority has reached unknown state! Check input parameter and broker."
+        f"Function get_priority has reached unknown state! Maybe unsupported broker {broker}?"
     )


### PR DESCRIPTION
Fixes a bug introduced in 1.8.0 that inadvertently drops support for many of our supported brokers, included amqp, amqps.

This fix is needed to run on Summit / ORNL