### PR TITLE
Bugfix for merlin purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- merlin purge queue name conflict & shell quote escape
 
 ## [1.8.0]
 

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -35,6 +35,7 @@ To see examples of yaml specifications, run `merlin example`.
 """
 import logging
 import os
+import shlex
 from io import StringIO
 
 import yaml
@@ -368,7 +369,7 @@ class MerlinSpec(YAMLSpecification):
         param steps: a list of step names
         """
         queues = ",".join(set(self.get_queue_list(steps)))
-        return f'"{queues}"'
+        return shlex.quote(queues)
 
     def get_worker_names(self):
         result = []

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -387,8 +387,9 @@ def purge_celery_tasks(queues, force):
     if force:
         force_com = " -f "
     purge_command = " ".join(["celery -A merlin purge", force_com, "-Q", queues])
+    LOG.debug(queues)
     LOG.debug(purge_command)
-    return subprocess.call(purge_command.split())
+    return subprocess.call(purge_command, shell=True)
 
 
 def stop_celery_workers(queues=None, spec_worker_names=None, worker_regex=None):


### PR DESCRIPTION
Fixes merlin purge with new queue names. Also uses shlex (std lib) to quote the queue strings instead of a "

Tested fix in both tcsh and bash
Also merlin run and run-workers still work