### PR TITLE
Release work: reformatting via Black, version update, minor test change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.8.1]
 
 ### Fixed
 - merlin purge queue name conflict & shell quote escape

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -38,7 +38,7 @@ import os
 import sys
 
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 VERSION = __version__
 PATH_TO_PROJ = os.path.join(os.path.dirname(__file__), "")
 

--- a/merlin/ascii_art.py
+++ b/merlin/ascii_art.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/__init__.py
+++ b/merlin/common/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/__init__.py
+++ b/merlin/common/abstracts/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/enums/__init__.py
+++ b/merlin/common/abstracts/enums/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/openfilelist.py
+++ b/merlin/common/openfilelist.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -287,13 +287,19 @@ class OpenNPYList:
         i: OpenNPY
         for i in self.files:
             i.load_header()
-        self.shapes: List[Tuple[int]] = [openNPY_obj.hdr["shape"] for openNPY_obj in self.files]
+        self.shapes: List[Tuple[int]] = [
+            openNPY_obj.hdr["shape"] for openNPY_obj in self.files
+        ]
         k: Tuple[int]
         for k in self.shapes[1:]:
             # Match subsequent axes shapes.
             if k[1:] != self.shapes[0][1:]:
-                raise AttributeError(f"Mismatch in subsequent axes shapes: {k[1:]} != {self.shapes[0][1:]}")
-        self.tells: np.ndarray = np.cumsum([arr_shape[0] for arr_shape in self.shapes])  # Tell locations.
+                raise AttributeError(
+                    f"Mismatch in subsequent axes shapes: {k[1:]} != {self.shapes[0][1:]}"
+                )
+        self.tells: np.ndarray = np.cumsum(
+            [arr_shape[0] for arr_shape in self.shapes]
+        )  # Tell locations.
         self.tells = np.hstack(([0], self.tells))
 
     def close(self):

--- a/merlin/common/sample_index.py
+++ b/merlin/common/sample_index.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/__init__.py
+++ b/merlin/common/security/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt.py
+++ b/merlin/common/security/encrypt.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt_backend_traffic.py
+++ b/merlin/common/security/encrypt_backend_traffic.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/util_sampling.py
+++ b/merlin/common/util_sampling.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -203,10 +203,9 @@ def get_cert_file(server_type, config, cert_name, cert_path):
     return cert_file
 
 
-def get_ssl_entries(server_type: str,
-                    server_name: str,
-                    server_config: Config,
-                    cert_path: str) -> str:
+def get_ssl_entries(
+    server_type: str, server_name: str, server_config: Config, cert_path: str
+) -> str:
     """
     Check if a ssl certificate file is present in the config
 
@@ -217,15 +216,21 @@ def get_ssl_entries(server_type: str,
     """
     server_ssl: Dict[str, Union[str, ssl.VerifyMode]] = {}
 
-    keyfile: Optional[str] = get_cert_file(server_type, server_config, "keyfile", cert_path)
+    keyfile: Optional[str] = get_cert_file(
+        server_type, server_config, "keyfile", cert_path
+    )
     if keyfile:
         server_ssl["keyfile"] = keyfile
 
-    certfile: Optional[str] = get_cert_file(server_type, server_config, "certfile", cert_path)
+    certfile: Optional[str] = get_cert_file(
+        server_type, server_config, "certfile", cert_path
+    )
     if certfile:
         server_ssl["certfile"] = certfile
 
-    ca_certsfile: Optional[str] = get_cert_file(server_type, server_config, "ca_certs", cert_path)
+    ca_certsfile: Optional[str] = get_cert_file(
+        server_type, server_config, "ca_certs", cert_path
+    )
     if ca_certsfile:
         server_ssl["ca_certs"] = ca_certsfile
 
@@ -280,8 +285,9 @@ def process_ssl_map(server_name: str) -> Optional[Dict[str, str]]:
     return ssl_map
 
 
-def merge_sslmap(server_ssl: Dict[str, Union[str, ssl.VerifyMode]],
-                 ssl_map: Dict[str, str]) -> Dict:
+def merge_sslmap(
+    server_ssl: Dict[str, Union[str, ssl.VerifyMode]], ssl_map: Dict[str, str]
+) -> Dict:
     """
     The different servers have different key var expectations, this updates the keys of the ssl_server dict with keys from
     the ssl_map if using rediss or mysql.

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/data/celery/__init__.py
+++ b/merlin/data/celery/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/__init__.py
+++ b/merlin/examples/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/examples.py
+++ b/merlin/examples/examples.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/generator.py
+++ b/merlin/examples/generator.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/workflows/flux/scripts/flux_info.py
+++ b/merlin/examples/workflows/flux/scripts/flux_info.py
@@ -23,7 +23,7 @@ done:
 import json
 import os
 import subprocess
-from typing import Dict, Union, IO
+from typing import IO, Dict, Union
 
 import flux
 from flux import kvs

--- a/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
+++ b/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
@@ -6,7 +6,9 @@ import subprocess
 from typing import List
 
 
-parser: argparse.ArgumentParser = argparse.ArgumentParser(description="Launch 35 merlin workflow jobs")
+parser: argparse.ArgumentParser = argparse.ArgumentParser(
+    description="Launch 35 merlin workflow jobs"
+)
 parser.add_argument("run_id", type=int, help="The ID of this run")
 parser.add_argument("output_path", type=str, help="the output path")
 parser.add_argument("spec_path", type=str, help="path to the spec to run")

--- a/merlin/exceptions/__init__.py
+++ b/merlin/exceptions/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/log_formatter.py
+++ b/merlin/log_formatter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/merlin_templates.py
+++ b/merlin/merlin_templates.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/__init__.py
+++ b/merlin/spec/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/defaults.py
+++ b/merlin/spec/defaults.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/expansion.py
+++ b/merlin/spec/expansion.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -124,9 +124,11 @@ class MerlinSpec(YAMLSpecification):
             merlin_block = yaml.safe_load(stream)["merlin"]
         except KeyError:
             merlin_block = {}
-            warning_msg: str = ("Workflow specification missing \n "
-                                "encouraged 'merlin' section! Run 'merlin example' for examples.\n"
-                                "Using default configuration with no sampling.")
+            warning_msg: str = (
+                "Workflow specification missing \n "
+                "encouraged 'merlin' section! Run 'merlin example' for examples.\n"
+                "Using default configuration with no sampling."
+            )
             LOG.warning(warning_msg)
         return merlin_block
 

--- a/merlin/study/__init__.py
+++ b/merlin/study/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -37,7 +37,7 @@ are implemented.
 """
 import logging
 import os
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
 from merlin.utils import get_yaml_var
 
@@ -111,10 +111,12 @@ def get_node_count(default=1):
     return default
 
 
-def batch_worker_launch(spec: Dict,
-                        com: str,
-                        nodes: Optional[Union[str, int]] = None,
-                        batch: Optional[Dict] = None) -> str:
+def batch_worker_launch(
+    spec: Dict,
+    com: str,
+    nodes: Optional[Union[str, int]] = None,
+    batch: Optional[Dict] = None,
+) -> str:
     """
     The configuration in the batch section of the merlin spec
     is used to create the worker launch line, which may be
@@ -147,7 +149,9 @@ def batch_worker_launch(spec: Dict,
     if nodes is None or nodes == "all":
         nodes = get_node_count(default=1)
     elif not isinstance(nodes, int):
-        raise TypeError("Nodes was passed into batch_worker_launch with an invalid type (likely a string other than 'all').")
+        raise TypeError(
+            "Nodes was passed into batch_worker_launch with an invalid type (likely a string other than 'all')."
+        )
 
     shell: str = get_yaml_var(batch, "shell", "bash")
 
@@ -169,7 +173,9 @@ def batch_worker_launch(spec: Dict,
     if btype == "flux":
         flux_path: str = get_yaml_var(batch, "flux_path", "")
         flux_opts: Union[str, Dict] = get_yaml_var(batch, "flux_start_opts", "")
-        flux_exec_workers: Union[str, Dict, bool] = get_yaml_var(batch, "flux_exec_workers", True)
+        flux_exec_workers: Union[str, Dict, bool] = get_yaml_var(
+            batch, "flux_exec_workers", True
+        )
 
         flux_exec: str = ""
         if flux_exec_workers:
@@ -180,9 +186,7 @@ def batch_worker_launch(spec: Dict,
 
         flux_exe: str = os.path.join(flux_path, "flux")
 
-        launch: str = (
-            f"{launch_command} {flux_exe} start {flux_opts} {flux_exec} `which {shell}` -c"
-        )
+        launch: str = f"{launch_command} {flux_exe} start {flux_opts} {flux_exec} `which {shell}` -c"
         worker_cmd = f'{launch} "{com}"'
     else:
         worker_cmd = f"{launch_command} {com}"
@@ -190,7 +194,9 @@ def batch_worker_launch(spec: Dict,
     return worker_cmd
 
 
-def construct_worker_launch_command(batch: Optional[Dict], btype: str, nodes: int) -> str:
+def construct_worker_launch_command(
+    batch: Optional[Dict], btype: str, nodes: int
+) -> str:
     """
     If no 'worker_launch' is found in the batch yaml, this method constructs the needed launch command.
 

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/dag.py
+++ b/merlin/study/dag.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/step.py
+++ b/merlin/study/step.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/tests/unit/study/test_study.py
+++ b/tests/unit/study/test_study.py
@@ -150,6 +150,7 @@ merlin:
 """
 
 
+# TODO many of these more resemble integration tests than unit tests, may want to review unit tests to make it more granular.
 def test_get_task_queue_default():
     """
     Given a steps dictionary that sets the task queue to `test_queue` return
@@ -279,22 +280,36 @@ class TestMerlinStudy(unittest.TestCase):
         If there is a common key between Maestro's global.parameters and
         Merlin's sample/column_labels, an error should be raised.
         """
-        merlin_spec_conflict: str = os.path.join(self.tmpdir, "basic_ensemble_conflict.yaml")
+        merlin_spec_conflict: str = os.path.join(
+            self.tmpdir, "basic_ensemble_conflict.yaml"
+        )
         with open(merlin_spec_conflict, "w+") as _file:
             _file.write(MERLIN_SPEC_CONFLICT)
         # for some reason flake8 doesn't believe variables instantiated inside the try/with context are assigned
         with pytest.raises(ValueError):
-            study_conflict: MerlinStudy = MerlinStudy(merlin_spec_conflict)  # noqa: F841
+            study_conflict: MerlinStudy = MerlinStudy(merlin_spec_conflict)
+            assert (
+                not study_conflict
+            ), "study_conflict completed construction without raising a ValueError."
 
+    # TODO the pertinent attribute for study_no_env should be examined and asserted to be empty
     def test_no_env(self):
         """
         A MerlinStudy should be able to support a MerlinSpec that does not contain
         the optional `env` section.
         """
-        merlin_spec_no_env_filepath: str = os.path.join(self.tmpdir, "basic_ensemble_no_env.yaml")
+        merlin_spec_no_env_filepath: str = os.path.join(
+            self.tmpdir, "basic_ensemble_no_env.yaml"
+        )
         with open(merlin_spec_no_env_filepath, "w+") as _file:
             _file.write(MERLIN_SPEC_NO_ENV)
         try:
-            study_no_env: MerlinStudy = MerlinStudy(merlin_spec_no_env_filepath)  # noqa: F841
+            study_no_env: MerlinStudy = MerlinStudy(merlin_spec_no_env_filepath)
+            bad_type_err: str = (
+                f"study_no_env failed construction, is type {type(study_no_env)}."
+            )
+            assert isinstance(study_no_env, MerlinStudy), bad_type_err
         except Exception as e:
-            assert False, f"Encountered unexpected exception, {e}, for viable MerlinSpec without optional 'env' section."
+            assert (
+                False
+            ), f"Encountered unexpected exception, {e}, for viable MerlinSpec without optional 'env' section."


### PR DESCRIPTION
Reformatted source using Black to be PEP compliant. Updated version number to 1.8.1. Minor modification to unit testing for test_no_env and test_column_conflict - this removed an unnecessary Flake8 stepover by using PyTest and examining test objects more thoroughly.