### PR TITLE
Pylint ci refactor

### DIFF
--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Run pytest over unit test suite
       run: |
-        python3 pytest tests/unit/
+        python3 -m pytest tests/unit/
 
     - name: Run integration test suite, locally
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -22,6 +22,7 @@ jobs:
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt
+	pip3 install pylint
 
     - name: Install merlin to run unit tests
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -40,9 +40,14 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --max-complexity=15 --statistics --max-line-length=127
 
+    - name: Lint with pylint
+      run: |
+        pylint merlin --rcfile=setup.cfg --exit-zero
+        pylint tests --rcfile=setup.cfg --exit-zero
+
     - name: Run pytest over unit test suite
       run: |
-        python3 -m pytest tests/unit/
+        pytest tests/unit/
 
     - name: Run integration test suite, locally
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -22,7 +22,7 @@ jobs:
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt
-	pip3 install pylint
+	python3 -m pip install pylint
 
     - name: Install merlin to run unit tests
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -3,9 +3,56 @@ name: Python CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  Changelog:
+    name: CHANGELOG.md updated
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Check that CHANGELOG has been updated
+      run: |
+        # If this step fails, this means you haven't updated the CHANGELOG.md
+        # file with notes on your contribution.
+        git diff --name-only $(git merge-base origin/main HEAD) | grep '^CHANGELOG.md$' && echo "Thanks for helping keep our CHANGELOG up-to-date!"
+
+  Lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Check cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
+        pip3 install --upgrade -r requirements/dev.txt
+
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --max-complexity=15 --statistics --max-line-length=127
+
+    - name: Lint with PyLint
+      run: |
+        python3 -m pylint merlin --rcfile=setup.cfg --exit-zero
+        python3 -m pylint tests --rcfile=setup.cfg --exit-zero
+
+  Run tests:
+    Runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -16,6 +63,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Check cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
 
     - name: Install dependencies
       run: |
@@ -32,18 +85,6 @@ jobs:
       run: |
         merlin example feature_demo
         pip3 install -r feature_demo/requirements.txt
-
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=15 --statistics --max-line-length=127
-
-    - name: Lint with pylint
-      run: |
-        python3 -m pylint merlin --rcfile=setup.cfg --exit-zero
-        python3 -m pylint tests --rcfile=setup.cfg --exit-zero
 
     - name: Run pytest over unit test suite
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -42,12 +42,12 @@ jobs:
 
     - name: Lint with pylint
       run: |
-        pylint merlin --rcfile=setup.cfg --exit-zero
-        pylint tests --rcfile=setup.cfg --exit-zero
+        python3 pylint merlin --rcfile=setup.cfg --exit-zero
+        python3 pylint tests --rcfile=setup.cfg --exit-zero
 
     - name: Run pytest over unit test suite
       run: |
-        pytest tests/unit/
+        python3 pytest tests/unit/
 
     - name: Run integration test suite, locally
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -52,7 +52,7 @@ jobs:
         python3 -m pylint tests --rcfile=setup.cfg --exit-zero
 
   Run tests:
-    Runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -42,8 +42,8 @@ jobs:
 
     - name: Lint with pylint
       run: |
-        python3 pylint merlin --rcfile=setup.cfg --exit-zero
-        python3 pylint tests --rcfile=setup.cfg --exit-zero
+        python3 -m pylint merlin --rcfile=setup.cfg --exit-zero
+        python3 -m pylint tests --rcfile=setup.cfg --exit-zero
 
     - name: Run pytest over unit test suite
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -51,7 +51,7 @@ jobs:
         python3 -m pylint merlin --rcfile=setup.cfg --exit-zero
         python3 -m pylint tests --rcfile=setup.cfg --exit-zero
 
-  Run tests:
+  Test-suite:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -22,7 +22,7 @@ jobs:
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt
-	python3 -m pip install pylint
+        pip3 install pylint
 
     - name: Install merlin to run unit tests
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -22,7 +22,6 @@ jobs:
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt
-        pip3 install pylint
 
     - name: Install merlin to run unit tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Added no-exit-fail PyLint pipeline to Github Actions CI.
+- Corrected integration test for dependency to only examine release dependencies.
+- PyLint adherence for: celery.py, opennplib.py, config/__init__.py, broker.py,
+  configfile.py, formatter.py, main.py, router.py
+
 ## [1.8.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added no-exit-fail PyLint pipeline to Github Actions CI.
+
+### Changed
+- CI now splits linting and testing into different tasks for better utilization of
+  parallel runners, significant and scalable speed gain over previous setup
+- CI now uses caching to restore environment of dependencies, reducing CI runtime
+  significantly again beyond the previous improvement. Examines for potential updates to
+  dependencies so the environment doesn't become stale.
+- CI now examines that the CHANGELOG is updated on PRs.
+- Added PyLint pipeline to Github Actions CI (currently no-fail-exit).
 - Corrected integration test for dependency to only examine release dependencies.
 - PyLint adherence for: celery.py, opennplib.py, config/__init__.py, broker.py,
   configfile.py, formatter.py, main.py, router.py

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ virtualenv:
 
 # install merlin into the virtual environment
 install-merlin: virtualenv
-	. $(VENV)/bin/activate; \
 	$(PIP) install -e .; \
 	merlin config; \
 
@@ -74,7 +73,7 @@ install-workflow-deps: virtualenv install-merlin
 
 
 # install requirements
-install-dev: virtualenv install-workflow-deps
+install-dev: virtualenv install-merlin install-workflow-deps
 	$(PIP) install -r requirements/dev.txt; \
 
 

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -142,10 +142,10 @@ def setup(**kwargs):  # pylint: disable=W0613
         # pylint is upset that typing accesses a protected class, ignoring W0212
         # pylint is upset that billiard doesn't have a current_process() method - it does
         current: billiard.process._MainProcess = (
-            billiard.current_process()
-        )  # pylint: disable=W0212, E1101
+            billiard.current_process()  # pylint: disable=W0212, E1101
+        )
         prefork_id: int = (
-            current._identity[0] - 1
-        )  # range 0:nworkers-1  # pylint: disable=W0212
+            current._identity[0] - 1  # pylint: disable=W0212
+        )  # range 0:nworkers-1
         cpu_slot: int = (prefork_id * cpu_skip) % npu
         process.cpu_affinity(list(range(cpu_slot, cpu_slot + cpu_skip)))

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -127,9 +127,8 @@ app.autodiscover_tasks(["merlin.common"])
 
 
 # Pylint believes the args are unused, I believe they're used after decoration
-# pylint: disable=W0613
 @worker_process_init.connect()
-def setup(**kwargs):
+def setup(**kwargs):  # pylint: disable=W0613
     """
     Set affinity for the worker on startup (works on toss3 nodes)
 
@@ -142,8 +141,11 @@ def setup(**kwargs):
         process: psutil.Process = psutil.Process()
         # pylint is upset that typing accesses a protected class, ignoring W0212
         # pylint is upset that billiard doesn't have a current_process() method - it does
-        # pylint: disable=W0212, E1101
-        current: billiard.process._MainProcess = billiard.current_process()
-        prefork_id: int = current._identity[0] - 1  # range 0:nworkers-1
+        current: billiard.process._MainProcess = (
+            billiard.current_process()
+        )  # pylint: disable=W0212, E1101
+        prefork_id: int = (
+            current._identity[0] - 1
+        )  # range 0:nworkers-1  # pylint: disable=W0212
         cpu_slot: int = (prefork_id * cpu_skip) % npu
         process.cpu_affinity(list(range(cpu_slot, cpu_slot + cpu_skip)))

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 import os
+from typing import Dict, Optional, Union
 
 import billiard
 import psutil
@@ -47,41 +48,43 @@ from merlin.router import route_for_task
 from merlin.utils import nested_namespace_to_dicts
 
 
-LOG = logging.getLogger(__name__)
+LOG: logging.Logger = logging.getLogger(__name__)
 
 merlin.common.security.encrypt_backend_traffic.set_backend_funcs()
 
 
-broker_ssl = True
-results_ssl = False
+BROKER_SSL: bool = True
+RESULTS_SSL: bool = False
+BROKER_URI: Optional[str] = ""
+RESULTS_BACKEND_URI: Optional[str] = ""
 try:
     BROKER_URI = broker.get_connection_string()
-    LOG.debug(f"broker: {broker.get_connection_string(include_password=False)}")
-    broker_ssl = broker.get_ssl_config()
-    LOG.debug(f"broker_ssl = {broker_ssl}")
+    LOG.debug("broker: %s", broker.get_connection_string(include_password=False))
+    BROKER_SSL = broker.get_ssl_config()
+    LOG.debug("broker_ssl = %s", BROKER_SSL)
     RESULTS_BACKEND_URI = results_backend.get_connection_string()
-    results_ssl = results_backend.get_ssl_config(celery_check=True)
+    RESULTS_SSL = results_backend.get_ssl_config(celery_check=True)
     LOG.debug(
-        f"results: {results_backend.get_connection_string(include_password=False)}"
+        "results: %s", results_backend.get_connection_string(include_password=False)
     )
-    LOG.debug(f"results: redis_backed_use_ssl = {results_ssl}")
+    LOG.debug("results: redis_backed_use_ssl = %s", RESULTS_SSL)
 except ValueError:
     # These variables won't be set if running with '--local'.
     BROKER_URI = None
     RESULTS_BACKEND_URI = None
 
 # initialize app with essential properties
-app = Celery(
+app: Celery = Celery(
     "merlin",
     broker=BROKER_URI,
     backend=RESULTS_BACKEND_URI,
-    broker_use_ssl=broker_ssl,
-    redis_backend_use_ssl=results_ssl,
+    broker_use_ssl=BROKER_SSL,
+    redis_backend_use_ssl=RESULTS_SSL,
     task_routes=(route_for_task,),
 )
 
 # set task priority defaults to prioritize workflow tasks over task-expansion tasks
-task_priority_defaults = {
+task_priority_defaults: Dict[str, Union[int, Priority]] = {
     "task_queue_max_priority": 10,
     "task_default_priority": get_priority(Priority.mid),
 }
@@ -97,15 +100,15 @@ app.conf.update(**celeryconfig.DICT)
 
 # load config overrides from app.yaml
 if (
-    (not hasattr(CONFIG.celery, "override"))
+    not hasattr(CONFIG.celery, "override")
     or (CONFIG.celery.override is None)
-    or (len(nested_namespace_to_dicts(CONFIG.celery.override)) == 0)
+    or (not nested_namespace_to_dicts(CONFIG.celery.override))  # only true if len == 0
 ):
     LOG.debug("Skipping celery config override; 'celery.override' field is empty.")
 else:
-    override_dict = nested_namespace_to_dicts(CONFIG.celery.override)
-    override_str = ""
-    i = 0
+    override_dict: Dict = nested_namespace_to_dicts(CONFIG.celery.override)
+    override_str: str = ""
+    i: int = 0
     for k, v in override_dict.items():
         if k not in str(app.conf.__dict__):
             raise ValueError(f"'{k}' is not a celery configuration.")
@@ -114,7 +117,8 @@ else:
             override_str += "\n"
         i += 1
     LOG.info(
-        f"Overriding default celery config with 'celery.override' in 'app.yaml':\n{override_str}"
+        "Overriding default celery config with 'celery.override' in 'app.yaml':\n%s",
+        override_str,
     )
     app.conf.update(**override_dict)
 
@@ -122,6 +126,8 @@ else:
 app.autodiscover_tasks(["merlin.common"])
 
 
+# Pylint believes the args are unused, I believe they're used after decoration
+# pylint: disable=W0613
 @worker_process_init.connect()
 def setup(**kwargs):
     """
@@ -131,10 +137,13 @@ def setup(**kwargs):
     """
     if "CELERY_AFFINITY" in os.environ and int(os.environ["CELERY_AFFINITY"]) > 1:
         # Number of cpus between workers.
-        cpu_skip = int(os.environ["CELERY_AFFINITY"])
-        npu = psutil.cpu_count()
-        p = psutil.Process()
-        current = billiard.current_process()
-        prefork_id = current._identity[0] - 1  # range 0:nworkers-1
-        cpu_slot = (prefork_id * cpu_skip) % npu
-        p.cpu_affinity(list(range(cpu_slot, cpu_slot + cpu_skip)))
+        cpu_skip: int = int(os.environ["CELERY_AFFINITY"])
+        npu: int = psutil.cpu_count()
+        process: psutil.Process = psutil.Process()
+        # pylint is upset that typing accesses a protected class, ignoring W0212
+        # pylint is upset that billiard doesn't have a current_process() method - it does
+        # pylint: disable=W0212, E1101
+        current: billiard.process._MainProcess = billiard.current_process()
+        prefork_id: int = current._identity[0] - 1  # range 0:nworkers-1
+        cpu_slot: int = (prefork_id * cpu_skip) % npu
+        process.cpu_affinity(list(range(cpu_slot, cpu_slot + cpu_skip)))

--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -81,6 +81,7 @@ access among all of them.
      print a.dtype      # dtype of array
 
 """
+
 from typing import List, Tuple
 
 import numpy as np

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -53,7 +53,7 @@ class Config:
         self.results_backend: Optional[SimpleNamespace]
         self.load_app_into_namespaces(app_dict)
 
-    def load_app_into_namespaces(self, app_dict: Dict):
+    def load_app_into_namespaces(self, app_dict: Dict) -> None:
         """
         Makes the application dictionary into a namespace, sets the attributes of the Config from the namespace values.
         """

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -32,6 +32,9 @@
 Used to store the application configuration.
 """
 
+from types import SimpleNamespace
+from typing import Dict, List, Optional
+
 from merlin.utils import nested_dict_to_namespaces
 
 
@@ -43,20 +46,20 @@ class Config:
     """
 
     def __init__(self, app_dict):
-        self.load_app(app_dict)
+        # I think this ends up a SimpleNamespace from load_app_into_namespaces, but it seems like it should be typed as
+        # the app var in celery.py, as celery.app.base.Celery
+        self.celery: Optional[SimpleNamespace]
+        self.broker: Optional[SimpleNamespace]
+        self.results_backend: Optional[SimpleNamespace]
+        self.load_app_into_namespaces(app_dict)
 
-    def load_namespaces(self, dic, fields):
+    def load_app_into_namespaces(self, app_dict: Dict):
         """
-        TODO
+        Makes the application dictionary into a namespace, sets the attributes of the Config from the namespace values.
         """
+        fields: List[str] = ["celery", "broker", "results_backend"]
         for field in fields:
             try:
-                setattr(self, field, nested_dict_to_namespaces(dic[field]))
+                setattr(self, field, nested_dict_to_namespaces(app_dict[field]))
             except KeyError:
                 pass
-
-    def load_app(self, dic):
-        """
-        Makes the application dictionary into a namespace.
-        """
-        self.load_namespaces(dic, ["celery", "broker", "results_backend"])

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -241,10 +241,13 @@ def _sort_valid_broker(broker, config_path, include_password):
     return get_redis_connection(config_path, include_password, ssl=True)
 
 
-def get_ssl_config() -> Union[bool, str]:
+def get_ssl_config() -> Union[bool, Dict[str, Union[str, ssl.VerifyMode]]]:
     """
     Return the ssl config based on the configuration specified in the
     `app.yaml` config file.
+
+    :return: Returns either False if no ssl
+    :rtype: Union[bool, Dict[str, Union[str, ssl.VerifyMode]]]
     """
     broker: Union[bool, str] = ""
     try:
@@ -266,7 +269,7 @@ def get_ssl_config() -> Union[bool, str]:
     except AttributeError:
         certs_path = None
 
-    broker_ssl: Dict[str, Union[str, ssl.VerifyMode]] = get_ssl_entries(
+    broker_ssl: Union[bool, Dict[str, Union[str, ssl.VerifyMode]]] = get_ssl_entries(
         "Broker", broker, CONFIG.broker, certs_path
     )
 

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -34,7 +34,9 @@ from __future__ import print_function
 import getpass
 import logging
 import os
+import ssl
 from os.path import expanduser
+from typing import Dict, List, Optional, Union
 
 from merlin.config.configfile import CONFIG, get_ssl_entries
 
@@ -45,12 +47,12 @@ except ImportError:
     from urllib.parse import quote
 
 
-LOG = logging.getLogger(__name__)
+LOG: logging.Logger = logging.getLogger(__name__)
 
-BROKERS = ["rabbitmq", "redis", "rediss", "redis+socket", "amqps", "amqp"]
+BROKERS: List[str] = ["rabbitmq", "redis", "rediss", "redis+socket", "amqps", "amqp"]
 
-RABBITMQ_CONNECTION = "{conn}://{username}:{password}@{server}:{port}/{vhost}"
-REDISSOCK_CONNECTION = "redis+socket://{path}?virtual_host={db_num}"
+RABBITMQ_CONNECTION: str = "{conn}://{username}:{password}@{server}:{port}/{vhost}"
+REDISSOCK_CONNECTION: str = "redis+socket://{path}?virtual_host={db_num}"
 USER = getpass.getuser()
 
 
@@ -239,12 +241,12 @@ def _sort_valid_broker(broker, config_path, include_password):
     return get_redis_connection(config_path, include_password, ssl=True)
 
 
-def get_ssl_config():
+def get_ssl_config() -> Union[bool, str]:
     """
     Return the ssl config based on the configuration specified in the
     `app.yaml` config file.
     """
-    broker = ""
+    broker: Union[bool, str] = ""
     try:
         broker = CONFIG.broker.url.split(":")[0]
     except AttributeError:
@@ -258,12 +260,15 @@ def get_ssl_config():
     if broker not in BROKERS:
         return False
 
+    certs_path: Optional[str]
     try:
         certs_path = CONFIG.celery.certs
     except AttributeError:
         certs_path = None
 
-    broker_ssl = get_ssl_entries("Broker", broker, CONFIG.broker, certs_path)
+    broker_ssl: Dict[str, Union[str, ssl.VerifyMode]] = get_ssl_entries(
+        "Broker", broker, CONFIG.broker, certs_path
+    )
 
     if not broker_ssl:
         broker_ssl = True

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -117,6 +117,8 @@ def get_config(path: Optional[str]) -> Dict:
     configurations.
 
     :param [Optional[str]] path : The path to search for the config file.
+    :return: the config file to coordinate brokers/results backend/task manager."
+    :rtype: A Dict with all the config data.
     """
     filepath: Optional[str] = find_config_file(path)
 

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -42,13 +42,13 @@ from merlin.config import Config
 from merlin.utils import load_yaml
 
 
-LOG = logging.getLogger(__name__)
+LOG: logging.Logger = logging.getLogger(__name__)
 
-APP_FILENAME = "app.yaml"
-CONFIG = None
+APP_FILENAME: str = "app.yaml"
+CONFIG: Optional[Config] = None
 
-USER_HOME = os.path.expanduser("~")
-MERLIN_HOME = os.path.join(USER_HOME, ".merlin")
+USER_HOME: str = os.path.expanduser("~")
+MERLIN_HOME: str = os.path.join(USER_HOME, ".merlin")
 
 
 def load_config(filepath):
@@ -111,21 +111,21 @@ def load_default_user_names(config):
         config["broker"]["vhost"] = vhost
 
 
-def get_config(path):
+def get_config(path: Optional[str]) -> Dict:
     """
     Load a merlin configuration file and return a dictionary of the
     configurations.
 
     :param path : The path to search for the config file.
     """
-    filepath = find_config_file(path)
+    filepath: Optional[str] = find_config_file(path)
 
     if filepath is None:
         raise ValueError(
             f"Cannot find a merlin config file! Run 'merlin config' and edit the file '{MERLIN_HOME}/{APP_FILENAME}'"
         )
 
-    config = load_config(filepath)
+    config: Dict = load_config(filepath)
     load_defaults(config)
     return config
 
@@ -307,5 +307,5 @@ def merge_sslmap(
     server_ssl = new_server_ssl
 
 
-app_config = get_config(None)
+app_config: Dict = get_config(None)
 CONFIG = Config(app_config)

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -116,7 +116,7 @@ def get_config(path: Optional[str]) -> Dict:
     Load a merlin configuration file and return a dictionary of the
     configurations.
 
-    :param path : The path to search for the config file.
+    :param [Optional[str]] path : The path to search for the config file.
     """
     filepath: Optional[str] = find_config_file(path)
 
@@ -205,14 +205,16 @@ def get_cert_file(server_type, config, cert_name, cert_path):
 
 def get_ssl_entries(
     server_type: str, server_name: str, server_config: Config, cert_path: str
-) -> str:
+) -> Dict[str, Union[str, ssl.VerifyMode]]:
     """
     Check if a ssl certificate file is present in the config
 
-    :param server_type : The server type
-    :param server_name : The server name for output
-    :param server_config : The server config
-    :param cert_path : The optional cert path
+    :param [str] server_type : The server type
+    :param [str] server_name : The server name for output
+    :param [Config] server_config : The server config
+    :param [str] cert_path : The optional cert path
+    :return : The data needed to manage an ssl certification.
+    :rtype : A Dict.
     """
     server_ssl: Dict[str, Union[str, ssl.VerifyMode]] = {}
 

--- a/merlin/log_formatter.py
+++ b/merlin/log_formatter.py
@@ -1,3 +1,5 @@
+"""This module handles setting up the extensive logging system in Merlin."""
+
 ###############################################################################
 # Copyright (c) 2019, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -1,3 +1,5 @@
+"""The top level main function for invoking Merlin."""
+
 ###############################################################################
 # Copyright (c) 2019, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory
@@ -43,8 +45,10 @@ from argparse import (
     RawTextHelpFormatter,
 )
 from contextlib import suppress
+from typing import Any, Dict, List, Optional, Union
 
 from merlin import VERSION, router
+from merlin import display
 from merlin.ascii_art import banner_small
 from merlin.examples.generator import list_examples, setup_example
 from merlin.log_formatter import setup_logging
@@ -68,33 +72,35 @@ class HelpParser(ArgumentParser):
         sys.exit(2)
 
 
-def verify_filepath(filepath):
+def verify_filepath(filepath) -> str:
     """
     Verify that the filepath argument is a valid
     file.
 
     :param `filepath`: the path of a file
     """
-    filepath = os.path.abspath(os.path.expandvars(os.path.expanduser(filepath)))
+    filepath: str = os.path.abspath(os.path.expandvars(os.path.expanduser(filepath)))
     if not os.path.isfile(filepath):
         raise ValueError(f"'{filepath}' is not a valid filepath")
     return filepath
 
 
-def verify_dirpath(dirpath):
+def verify_dirpath(dirpath) -> str:
     """
     Verify that the dirpath argument is a valid
     directory.
 
     :param `dirpath`: the path of a directory
     """
-    dirpath = os.path.abspath(os.path.expandvars(os.path.expanduser(dirpath)))
+    dirpath: str = os.path.abspath(os.path.expandvars(os.path.expanduser(dirpath)))
     if not os.path.isdir(dirpath):
         raise ValueError(f"'{dirpath}' is not a valid directory path")
     return dirpath
 
 
-def parse_override_vars(variables_list):
+def parse_override_vars(
+    variables_list: Optional[List[str]],
+) -> Optional[Dict[str, Union[str, int]]]:
     """
     Parse a list of variables from command line syntax
     into a valid dictionary of variable keys and values.
@@ -104,19 +110,20 @@ def parse_override_vars(variables_list):
     if variables_list is None:
         return None
     LOG.debug(f"Command line override variables = {variables_list}")
-    result = {}
+    result: Dict[str, Union[str, int]] = {}
+    arg: str
     for arg in variables_list:
         try:
             if "=" not in arg:
                 raise ValueError(
                     "--vars requires '=' operator. See 'merlin run --help' for an example."
                 )
-            entry = arg.split("=")
+            entry: str = arg.split("=")
             if len(entry) != 2:
                 raise ValueError(
                     "--vars requires ONE '=' operator (without spaces) per variable assignment."
                 )
-            key = entry[0]
+            key: str = entry[0]
             if key is None or key == "" or "$" in key:
                 raise ValueError(
                     "--vars requires valid variable names comprised of alphanumeric characters and underscores."
@@ -126,15 +133,15 @@ def parse_override_vars(variables_list):
                     f"Cannot override reserved word '{key}'! Reserved words are: {RESERVED}."
                 )
 
-            val = entry[1]
+            val: Union[str, int] = entry[1]
             with suppress(ValueError):
                 int(val)
                 val = int(val)
             result[key] = val
 
-        except BaseException as e:
+        except Exception as excpt:
             raise ValueError(
-                f"{e} Bad '--vars' formatting on command line. See 'merlin run --help' for an example."
+                f"{excpt} Bad '--vars' formatting on command line. See 'merlin run --help' for an example."
             )
     return result
 
@@ -158,9 +165,9 @@ def process_run(args):
     :param `args`: parsed CLI arguments
     """
     print(banner_small)
-    filepath = verify_filepath(args.specification)
-    variables_dict = parse_override_vars(args.variables)
-    samples_file = None
+    filepath: str = verify_filepath(args.specification)
+    variables_dict: str = parse_override_vars(args.variables)
+    samples_file: Optional[str] = None
     if args.samples_file:
         samples_file = verify_filepath(args.samples_file)
 
@@ -172,7 +179,7 @@ def process_run(args):
     if args.pgen_file:
         verify_filepath(args.pgen_file)
 
-    study = MerlinStudy(
+    study: MerlinStudy = MerlinStudy(
         filepath,
         override_vars=variables_dict,
         samples_file=samples_file,
@@ -191,20 +198,20 @@ def process_restart(args):
     :param `args`: parsed CLI arguments
     """
     print(banner_small)
-    restart_dir = verify_dirpath(args.restart_dir)
-    filepath = os.path.join(args.restart_dir, "merlin_info", "*.expanded.yaml")
-    possible_specs = glob.glob(filepath)
+    restart_dir: str = verify_dirpath(args.restart_dir)
+    filepath: str = os.path.join(args.restart_dir, "merlin_info", "*.expanded.yaml")
+    possible_specs: Optional[List[str]] = glob.glob(filepath)
     if len(possible_specs) == 0:
         raise ValueError(
             f"'{filepath}' does not match any provenance spec file to restart from."
         )
-    elif len(possible_specs) > 1:
+    if len(possible_specs) > 1:
         raise ValueError(
             f"'{filepath}' matches more than one provenance spec file to restart from."
         )
-    filepath = verify_filepath(possible_specs[0])
+    filepath: str = verify_filepath(possible_specs[0])
     LOG.info(f"Restarting workflow at '{restart_dir}'")
-    study = MerlinStudy(filepath, restart_dir=restart_dir)
+    study: MerlinStudy = MerlinStudy(filepath, restart_dir=restart_dir)
     router.run_task_server(study, args.run_mode)
 
 
@@ -297,8 +304,6 @@ def print_info(args):
 
     :param `args`: parsed CLI arguments
     """
-    from merlin import display
-
     display.print_info(args)
 
 
@@ -308,14 +313,15 @@ def config_merlin(args):
 
     :param `args`: parsed CLI arguments
     """
-    output_dir = args.output_dir
+    output_dir: str = args.output_dir
     if output_dir is None:
         USER_HOME = os.path.expanduser("~")
         output_dir = os.path.join(USER_HOME, ".merlin")
     _ = router.create_config(args.task_server, output_dir, args.broker)
 
 
-def process_example(args):
+def process_example(args) -> None:
+    """Sets the default values for the example subparser. This is passed as a functor."""
     if args.workflow == "list":
         print(list_examples())
     else:
@@ -338,18 +344,18 @@ def process_monitor(args):
     LOG.info("Monitor: ... stop condition met")
 
 
-def setup_argparse():
+def setup_argparse() -> None:
     """
     Setup argparse and any CLI options we want available via the package.
     """
-    parser = HelpParser(
+    parser: HelpParser = HelpParser(
         prog="merlin",
         description=banner_small,
         formatter_class=RawDescriptionHelpFormatter,
         epilog="See merlin <command> --help for more info",
     )
     parser.add_argument("-v", "--version", action="version", version=VERSION)
-    subparsers = parser.add_subparsers(dest="subparsers")
+    subparsers: ArgumentParser = parser.add_subparsers(dest="subparsers")
     subparsers.required = True
 
     # merlin --level
@@ -365,7 +371,7 @@ def setup_argparse():
     )
 
     # merlin run
-    run = subparsers.add_parser(
+    run: ArgumentParser = subparsers.add_parser(
         "run",
         help="Run a workflow using a Merlin or Maestro YAML study " "specification.",
         formatter_class=ArgumentDefaultsHelpFormatter,
@@ -434,7 +440,7 @@ def setup_argparse():
     )
 
     # merlin restart
-    restart = subparsers.add_parser(
+    restart: ArgumentParser = subparsers.add_parser(
         "restart",
         help="Restart a workflow using an existing Merlin workspace.",
         formatter_class=ArgumentDefaultsHelpFormatter,
@@ -452,8 +458,196 @@ def setup_argparse():
         help="Run locally instead of distributed",
     )
 
+    # merlin purge
+    purge: ArgumentParser = subparsers.add_parser(
+        "purge",
+        help="Remove all tasks from all merlin queues (default).              "
+        "If a user would like to purge only selected queues use:    "
+        "--steps to give a steplist, the queues will be defined from the step list",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    purge.set_defaults(func=purge_tasks)
+    purge.add_argument(
+        "specification", type=str, help="Path to a Merlin YAML spec file"
+    )
+    purge.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        dest="purge_force",
+        default=False,
+        help="Purge the tasks without confirmation",
+    )
+    purge.add_argument(
+        "--steps",
+        nargs="+",
+        type=str,
+        dest="purge_steps",
+        default=["all"],
+        help="The specific steps in the YAML file from which you want to purge the queues. \
+        The input is a space separated list.",
+    )
+    purge.add_argument(
+        "--vars",
+        action="store",
+        dest="variables",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
+        "Example: '--vars MY_QUEUE=hello'",
+    )
+
+    # merlin status
+    status: ArgumentParser = subparsers.add_parser(
+        "status",
+        help="List server stats (name, number of tasks to do, \
+                              number of connected workers) for a workflow spec.",
+    )
+    status.set_defaults(func=query_status)
+    status.add_argument(
+        "specification", type=str, help="Path to a Merlin YAML spec file"
+    )
+    status.add_argument(
+        "--steps",
+        nargs="+",
+        type=str,
+        dest="steps",
+        default=["all"],
+        help="The specific steps in the YAML file you want to query",
+    )
+    status.add_argument(
+        "--task_server",
+        type=str,
+        default="celery",
+        help="Task server type.\
+                            Default: %(default)s",
+    )
+    status.add_argument(
+        "--vars",
+        action="store",
+        dest="variables",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
+        "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
+    )
+    status.add_argument(
+        "--csv", type=str, help="csv file to dump status report to", default=None
+    )
+
+    # merlin info
+    info: ArgumentParser = subparsers.add_parser(
+        "info",
+        help="display info about the merlin configuration and the python configuration. Useful for debugging.",
+    )
+    info.set_defaults(func=print_info)
+
+    mconfig: ArgumentParser = subparsers.add_parser(
+        "config",
+        help="Create a default merlin server config file in ~/.merlin",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    mconfig.set_defaults(func=config_merlin)
+    mconfig.add_argument(
+        "--task_server",
+        type=str,
+        default="celery",
+        help="Task server type for which to create the config.\
+                            Default: %(default)s",
+    )
+    mconfig.add_argument(
+        "-o",
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Optional directory to place the default config file.\
+                            Default: ~/.merlin",
+    )
+    mconfig.add_argument(
+        "--broker",
+        type=str,
+        default=None,
+        help="Optional broker type, backend will be redis\
+                            Default: rabbitmq",
+    )
+
+    # merlin example
+    example: ArgumentParser = subparsers.add_parser(
+        "example",
+        help="Generate an example merlin workflow.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    example.add_argument(
+        "workflow",
+        action="store",
+        type=str,
+        help="The name of the example workflow to setup. Use 'merlin example list' to see available options.",
+    )
+    example.add_argument(
+        "-p",
+        "--path",
+        action="store",
+        type=str,
+        default=None,
+        help="Specify a path to write the workflow to. Defaults to current "
+        "working directory",
+    )
+    example.set_defaults(func=process_example)
+
+    # merlin monitor
+    monitor: ArgumentParser = subparsers.add_parser(
+        "monitor",
+        help="Check for active workers on an allocation.",
+        formatter_class=RawTextHelpFormatter,
+    )
+    monitor.add_argument(
+        "specification", type=str, help="Path to a Merlin YAML spec file"
+    )
+    monitor.add_argument(
+        "--steps",
+        nargs="+",
+        type=str,
+        dest="steps",
+        default=["all"],
+        help="The specific steps (tasks on the server) in the YAML file defining the queues you want to monitor",
+    )
+    monitor.add_argument(
+        "--vars",
+        action="store",
+        dest="variables",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
+        "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
+    )
+    monitor.add_argument(
+        "--task_server",
+        type=str,
+        default="celery",
+        help="Task server type for which to monitor the workers.\
+                              Default: %(default)s",
+    )
+    monitor.add_argument(
+        "--sleep",
+        type=int,
+        default=60,
+        help="Sleep duration between checking for workers.\
+                                    Default: %(default)s",
+    )
+    monitor.set_defaults(func=process_monitor)
+
+    generate_worker_controlling_parsers(subparsers)
+
+    return parser
+
+
+def generate_worker_controlling_parsers(subparsers: ArgumentParser) -> None:
+    """All commands directly controlling or invoking workers are generated here."""
     # merlin run-workers
-    run_workers = subparsers.add_parser(
+    run_workers: ArgumentParser = subparsers.add_parser(
         "run-workers",
         help="Run the workers associated with the Merlin YAML study "
         "specification. Does -not- queue tasks, just workers tied "
@@ -497,47 +691,21 @@ def setup_argparse():
         "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
     )
 
-    # merlin purge
-    purge = subparsers.add_parser(
-        "purge",
-        help="Remove all tasks from all merlin queues (default).              "
-        "If a user would like to purge only selected queues use:    "
-        "--steps to give a steplist, the queues will be defined from the step list",
-        formatter_class=ArgumentDefaultsHelpFormatter,
+    # merlin query-workers
+    query: ArgumentParser = subparsers.add_parser(
+        "query-workers", help="List connected task server workers."
     )
-    purge.set_defaults(func=purge_tasks)
-    purge.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
-    purge.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        dest="purge_force",
-        default=False,
-        help="Purge the tasks without confirmation",
-    )
-    purge.add_argument(
-        "--steps",
-        nargs="+",
+    query.set_defaults(func=query_workers)
+    query.add_argument(
+        "--task_server",
         type=str,
-        dest="purge_steps",
-        default=["all"],
-        help="The specific steps in the YAML file from which you want to purge the queues. The input is a space separated list.",
-    )
-    purge.add_argument(
-        "--vars",
-        action="store",
-        dest="variables",
-        type=str,
-        nargs="+",
-        default=None,
-        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
-        "Example: '--vars MY_QUEUE=hello'",
+        default="celery",
+        help="Task server type from which to query workers.\
+                            Default: %(default)s",
     )
 
     # merlin stop-workers
-    stop = subparsers.add_parser(
+    stop: ArgumentParser = subparsers.add_parser(
         "stop-workers", help="Attempt to stop all task server workers."
     )
     stop.set_defaults(func=stop_workers)
@@ -564,162 +732,6 @@ def setup_argparse():
         help="regex match for specific workers to stop",
     )
 
-    # merlin query-workers
-    query = subparsers.add_parser(
-        "query-workers", help="List connected task server workers."
-    )
-    query.set_defaults(func=query_workers)
-    query.add_argument(
-        "--task_server",
-        type=str,
-        default="celery",
-        help="Task server type from which to query workers.\
-                            Default: %(default)s",
-    )
-
-    # merlin status
-    status = subparsers.add_parser(
-        "status",
-        help="List server stats (name, number of tasks to do, \
-                              number of connected workers) for a workflow spec.",
-    )
-    status.set_defaults(func=query_status)
-    status.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
-    status.add_argument(
-        "--steps",
-        nargs="+",
-        type=str,
-        dest="steps",
-        default=["all"],
-        help="The specific steps in the YAML file you want to query",
-    )
-    status.add_argument(
-        "--task_server",
-        type=str,
-        default="celery",
-        help="Task server type.\
-                            Default: %(default)s",
-    )
-    status.add_argument(
-        "--vars",
-        action="store",
-        dest="variables",
-        type=str,
-        nargs="+",
-        default=None,
-        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
-        "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
-    )
-    status.add_argument(
-        "--csv", type=str, help="csv file to dump status report to", default=None
-    )
-
-    # merlin info
-    info = subparsers.add_parser(
-        "info",
-        help="display info about the merlin configuration and the python configuration. Useful for debugging.",
-    )
-    info.set_defaults(func=print_info)
-
-    mconfig = subparsers.add_parser(
-        "config",
-        help="Create a default merlin server config file in ~/.merlin",
-        formatter_class=ArgumentDefaultsHelpFormatter,
-    )
-    mconfig.set_defaults(func=config_merlin)
-    mconfig.add_argument(
-        "--task_server",
-        type=str,
-        default="celery",
-        help="Task server type for which to create the config.\
-                            Default: %(default)s",
-    )
-    mconfig.add_argument(
-        "-o",
-        "--output_dir",
-        type=str,
-        default=None,
-        help="Optional directory to place the default config file.\
-                            Default: ~/.merlin",
-    )
-    mconfig.add_argument(
-        "--broker",
-        type=str,
-        default=None,
-        help="Optional broker type, backend will be redis\
-                            Default: rabbitmq",
-    )
-
-    # merlin example
-    example = subparsers.add_parser(
-        "example",
-        help="Generate an example merlin workflow.",
-        formatter_class=RawTextHelpFormatter,
-    )
-    example.add_argument(
-        "workflow",
-        action="store",
-        type=str,
-        help="The name of the example workflow to setup. Use 'merlin example list' to see available options.",
-    )
-    example.add_argument(
-        "-p",
-        "--path",
-        action="store",
-        type=str,
-        default=None,
-        help="Specify a path to write the workflow to. Defaults to current "
-        "working directory",
-    )
-    example.set_defaults(func=process_example)
-
-    # merlin monitor
-    monitor = subparsers.add_parser(
-        "monitor",
-        help="Check for active workers on an allocation.",
-        formatter_class=RawTextHelpFormatter,
-    )
-    monitor.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
-    monitor.add_argument(
-        "--steps",
-        nargs="+",
-        type=str,
-        dest="steps",
-        default=["all"],
-        help="The specific steps (tasks on the server) in the YAML file defining the queues you want to monitor",
-    )
-    monitor.add_argument(
-        "--vars",
-        action="store",
-        dest="variables",
-        type=str,
-        nargs="+",
-        default=None,
-        help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
-        "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
-    )
-    monitor.add_argument(
-        "--task_server",
-        type=str,
-        default="celery",
-        help="Task server type for which to monitor the workers.\
-                              Default: %(default)s",
-    )
-    monitor.add_argument(
-        "--sleep",
-        type=int,
-        default=60,
-        help="Sleep duration between checking for workers.\
-                                    Default: %(default)s",
-    )
-    monitor.set_defaults(func=process_monitor)
-
-    return parser
-
 
 def main():
     """
@@ -735,9 +747,9 @@ def main():
 
     try:
         args.func(args)
-    except Exception as e:
+    except Exception as excpt:
         LOG.debug(traceback.format_exc())
-        LOG.error(str(e))
+        LOG.error(str(excpt))
         return 1
 
 

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -41,6 +41,7 @@ import traceback
 from argparse import (
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
+    Namespace,
     RawDescriptionHelpFormatter,
     RawTextHelpFormatter,
 )
@@ -71,25 +72,31 @@ class HelpParser(ArgumentParser):
         sys.exit(2)
 
 
-def verify_filepath(filepath) -> str:
+def verify_filepath(filepath: str) -> str:
     """
     Verify that the filepath argument is a valid
     file.
 
-    :param `filepath`: the path of a file
+    :param [str] `filepath`: the path of a file
+
+    :return: the verified absolute filepath with expanded environment variables.
+    :rtype: str
     """
-    filepath: str = os.path.abspath(os.path.expandvars(os.path.expanduser(filepath)))
+    filepath = os.path.abspath(os.path.expandvars(os.path.expanduser(filepath)))
     if not os.path.isfile(filepath):
         raise ValueError(f"'{filepath}' is not a valid filepath")
     return filepath
 
 
-def verify_dirpath(dirpath) -> str:
+def verify_dirpath(dirpath: str) -> str:
     """
     Verify that the dirpath argument is a valid
     directory.
 
-    :param `dirpath`: the path of a directory
+    :param [str] `dirpath`: the path of a directory
+
+    :return: returns the absolute path with expanded environment vars for a given dirpath.
+    :rtype: str
     """
     dirpath: str = os.path.abspath(os.path.expandvars(os.path.expanduser(dirpath)))
     if not os.path.isdir(dirpath):
@@ -104,7 +111,10 @@ def parse_override_vars(
     Parse a list of variables from command line syntax
     into a valid dictionary of variable keys and values.
 
-    :param `variables_list`: a list of strings, e.g. ["KEY=val",...]
+    :param [List[str]] `variables_list`: an optional list of strings, e.g. ["KEY=val",...]
+
+    :return: returns either None or a Dict keyed with strs, linked to strs and ints.
+    :rtype: Dict
     """
     if variables_list is None:
         return None
@@ -157,11 +167,11 @@ def get_merlin_spec_with_override(args):
     return spec, filepath
 
 
-def process_run(args):
+def process_run(args: Namespace) -> None:
     """
     CLI command for running a study.
 
-    :param `args`: parsed CLI arguments
+    :param [Namespace] `args`: parsed CLI arguments
     """
     print(banner_small)
     filepath: str = verify_filepath(args.specification)
@@ -190,11 +200,11 @@ def process_run(args):
     router.run_task_server(study, args.run_mode)
 
 
-def process_restart(args):
+def process_restart(args: Namespace) -> None:
     """
     CLI command for restarting a study.
 
-    :param `args`: parsed CLI arguments
+    :param [Namespace] `args`: parsed CLI arguments
     """
     print(banner_small)
     restart_dir: str = verify_dirpath(args.restart_dir)
@@ -309,11 +319,11 @@ def print_info(args):
     display.print_info(args)
 
 
-def config_merlin(args: Dict) -> None:
+def config_merlin(args: Namespace) -> None:
     """
     CLI command to setup default merlin config.
 
-    :param `args`: parsed CLI arguments
+    :param [Namespace] `args`: parsed CLI arguments
     """
     output_dir: Optional[str] = args.output_dir
     if output_dir is None:
@@ -322,8 +332,11 @@ def config_merlin(args: Dict) -> None:
     router.create_config(args.task_server, output_dir, args.broker)
 
 
-def process_example(args) -> None:
-    """Sets the default values for the example subparser. This is passed as a functor."""
+def process_example(args: Namespace) -> None:
+    """Either lists all example workflows, or sets up an example as a workflow to be run at root dir.
+
+    :param [Namespace] `args`: parsed CLI arguments
+    """
     if args.workflow == "list":
         print(list_examples())
     else:
@@ -560,7 +573,11 @@ def setup_argparse() -> None:
 
 
 def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
-    """All CLI arg parsers directly controlling or invoking workers are generated here."""
+    """All CLI arg parsers directly controlling or invoking workers are generated here.
+
+    :param [ArgumentParser] `subparsers`: the subparsers needed for every CLI command that directly controls or invokes
+        workers.
+    """
     # merlin run-workers
     run_workers: ArgumentParser = subparsers.add_parser(
         "run-workers",
@@ -692,7 +709,11 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
 
 
 def generate_diagnostic_parsers(subparsers: ArgumentParser) -> None:
-    """All CLI arg parsers generally used diagnostically are generated here."""
+    """All CLI arg parsers generally used diagnostically are generated here.
+
+    :param [ArgumentParser] `subparsers`: the subparsers needed for every CLI command that handles diagnostics for a
+        Merlin job.
+    """
     # merlin status
     status: ArgumentParser = subparsers.add_parser(
         "status",

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -211,8 +211,9 @@ def create_config(task_server: str, config_dir: str, broker: str) -> None:
     """
     Create a config for the given task server.
 
-    :param `task_server`: The task server from which to stop workers.
-    :param `config_dir`: Optional directory to install the config.
+    :param [str] `task_server`: The task server from which to stop workers.
+    :param [str] `config_dir`: Optional directory to install the config.
+    :param [str] `broker`: string indicated the broker, used to check for redis.
     """
     LOG.info("Creating config ...")
 

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -207,7 +207,7 @@ def route_for_task(name, args, kwargs, options, task=None, **kw):
         return {"queue": queue}
 
 
-def create_config(task_server, config_dir, broker):
+def create_config(task_server: str, config_dir: str, broker: str) -> None:
     """
     Create a config for the given task server.
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@ dep-license
 flake8
 isort
 pytest
-pylint
 twine
 sphinx>=2.0.0
 alabaster

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@ dep-license
 flake8
 isort
 pytest
+pylint
 twine
 sphinx>=2.0.0
 alabaster

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,11 @@ max-complexity = 15
 select = B,C,E,F,W,T4
 exclude = .git,__pycache__,ascii_art.py,merlin/examples/*,*venv*
 
+
+[pylint.FORMAT]
+ignore=*venv*
+
+
 [mypy]
 files=best_practices,test
 ignore_missing_imports=true

--- a/tests/integration/test_definitions.py
+++ b/tests/integration/test_definitions.py
@@ -38,6 +38,7 @@ def define_tests():
     lsf = f"{examples}/lsf/lsf_par.yaml"
     black = "black --check --target-version py36"
     config_dir = "./CLI_TEST_MERLIN_CONFIG"
+    release_dependencies = "./requirements/release.txt"
 
     basic_checks = {
         "merlin": ("merlin", HasReturnCode(1), "local"),
@@ -317,7 +318,7 @@ def define_tests():
     }
     dependency_checks = {
         "deplic no GNU": (
-            "deplic ./",
+            f"deplic {release_dependencies}",
             [HasRegex("GNU", negate=True), HasRegex("GPL", negate=True)],
             "local",
         ),


### PR DESCRIPTION
This has the first handful of PyLint refactored files. This refactor is too large for one pass, so it will be broken up across several PRs. Like the Flake8 refactor, any classes/functions that were touched by this were (generally) given type hints to make the transition to enforcing MyPy easier when that comes online.