### PR TITLE
'Shell console output fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PyLint pipeline to Github Actions CI (currently no-fail-exit).
 - Corrected integration test for dependency to only examine release dependencies.
 - PyLint adherence for: celery.py, opennplib.py, config/__init__.py, broker.py,
-  configfile.py, formatter.py, main.py, router.py
+	configfile.py, formatter.py, main.py, router.py
+
+### Fixed
+- 'shell' added to unsupported and new_unsupported lists in script_adapter.py, prevents
+  `'shell' is not supported -- ommitted` message.
+- Makefile target for install-merlin fixed so venv is properly activated to install merlin
 
 ## [1.8.1]
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ virtualenv:
 # install merlin into the virtual environment
 install-merlin: virtualenv
 	$(PIP) install -e .; \
+	. $(VENV)/bin/activate; \
 	merlin config; \
 
 

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -34,6 +34,7 @@ Merlin script adapter module
 
 import logging
 import os
+from typing import Dict, List, Set
 
 from maestrowf.interfaces.script import SubmissionRecord
 from maestrowf.interfaces.script.localscriptadapter import LocalScriptAdapter
@@ -66,7 +67,7 @@ class MerlinLSFScriptAdapter(SlurmScriptAdapter):
         """
         super(MerlinLSFScriptAdapter, self).__init__(**kwargs)
 
-        self._cmd_flags = {
+        self._cmd_flags: Dict[str, str] = {
             "cmd": "jsrun",
             "ntasks": "--np",
             "nodes": "--nrs",
@@ -79,22 +80,23 @@ class MerlinLSFScriptAdapter(SlurmScriptAdapter):
             "lsf": "",
         }
 
-        self._unsupported = {
+        self._unsupported: Set[str] = {
             "cmd",
-            "ntasks",
-            "nodes",
+            "depends",
+            "flux",
             "gpus",
-            "walltime",
+            "max_retries",
+            "nodes",
+            "ntasks",
+            "post",
+            "pre",
             "reservation",
             "restart",
-            "task_queue",
-            "max_retries",
             "retry_delay",
-            "pre",
-            "post",
-            "depends",
+            "shell",
             "slurm",
-            "flux",
+            "task_queue",
+            "walltime",
         }
 
     def get_header(self, step):
@@ -158,7 +160,7 @@ class MerlinSlurmScriptAdapter(SlurmScriptAdapter):
     the SlurmScriptAdapter uses non-blocking submits.
     """
 
-    key = "merlin-slurm"
+    key: str = "merlin-slurm"
 
     def __init__(self, **kwargs):
         """
@@ -174,20 +176,21 @@ class MerlinSlurmScriptAdapter(SlurmScriptAdapter):
         self._cmd_flags["slurm"] = ""
         self._cmd_flags["walltime"] = "-t"
 
-        new_unsupported = [
-            "task_queue",
-            "max_retries",
-            "retry_delay",
-            "pre",
-            "post",
+        new_unsupported: List[str] = [
+            "bind",
+            "flux",
             "gpus per task",
             "gpus",
-            "restart",
-            "bind",
             "lsf",
-            "flux",
+            "max_retries",
+            "post",
+            "pre",
+            "restart",
+            "retry_delay",
+            "shell",
+            "task_queue",
         ]
-        self._unsupported = set(list(self._unsupported) + new_unsupported)
+        self._unsupported: Set[str] = set(list(self._unsupported) + new_unsupported)
 
     def get_header(self, step):
         """


### PR DESCRIPTION
Patch to suppress console output about unsupported shell, minor fix to Makefile target.

Updated self._unsupported and new_unsupported in script_adapter.py to include 'shell', overcoming console arning about shell being unsupported. Typing added to touched class __inits__.
Makefile had an error in install-merlin that wasn't activating the venv, now activates to enable that target as well as install-dev.