### PR TITLE
Enforce black and isort in the CI

### DIFF
--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -46,6 +46,18 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --max-complexity=15 --statistics --max-line-length=127
 
+    - name: Lint with isort
+      run: |
+        python3 -m isort --check --line-length 127 merlin
+        python3 -m isort --check --line-length 127 tests
+        python3 -m isort --check --line-length 127 *.py
+
+    - name: Lint with Black
+      run: |
+        python3 -m black --check --line-length 127 --target-version py36 merlin
+        python3 -m black --check --line-length 127 --target-version py36 tests
+        python3 -m black --check --line-length 127 --target-version py36 *.py
+
     - name: Lint with PyLint
       run: |
         python3 -m pylint merlin --rcfile=setup.cfg --exit-zero

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -13,12 +13,14 @@ jobs:
 
     - name: Check that CHANGELOG has been updated
       run: |
-        # If this step fails, this means you haven't updated the CHANGELOG.md
-        # file with notes on your contribution.
+        # If this step fails, this means you haven't updated the CHANGELOG.md file with notes on your contribution.
         git diff --name-only $(git merge-base origin/main HEAD) | grep '^CHANGELOG.md$' && echo "Thanks for helping keep our CHANGELOG up-to-date!"
 
   Lint:
     runs-on: ubuntu-latest
+    env:
+      MAX_LINE_LENGTH: 127
+      MAX_COMPLEXITY: 15
 
     steps:
     - uses: actions/checkout@v2
@@ -44,19 +46,19 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=15 --statistics --max-line-length=127
+        flake8 . --count --max-complexity=$MAX_COMPLEXITY --statistics --max-line-length=$MAX_LINE_LENGTH
 
     - name: Lint with isort
       run: |
-        python3 -m isort --check --line-length 127 merlin
-        python3 -m isort --check --line-length 127 tests
-        python3 -m isort --check --line-length 127 *.py
+        python3 -m isort --check --line-length $MAX_LINE_LENGTH merlin
+        python3 -m isort --check --line-length $MAX_LINE_LENGTH tests
+        python3 -m isort --check --line-length $MAX_LINE_LENGTH *.py
 
     - name: Lint with Black
       run: |
-        python3 -m black --check --line-length 127 --target-version py36 merlin
-        python3 -m black --check --line-length 127 --target-version py36 tests
-        python3 -m black --check --line-length 127 --target-version py36 *.py
+        python3 -m black --check --line-length $MAX_LINE_LENGTH --target-version py36 merlin
+        python3 -m black --check --line-length $MAX_LINE_LENGTH --target-version py36 tests
+        python3 -m black --check --line-length $MAX_LINE_LENGTH --target-version py36 *.py
 
     - name: Lint with PyLint
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PyLint pipeline to Github Actions CI (currently no-fail-exit).
 - Corrected integration test for dependency to only examine release dependencies.
 - PyLint adherence for: celery.py, opennplib.py, config/__init__.py, broker.py,
-  configfile.py, formatter.py, main.py, router.py
+configfile.py, formatter.py, main.py, router.py
+- Integrated Black and isort into CI
 
 ## [1.8.1]
 

--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,13 @@ checks: check-style check-camel-case
 
 # automatically make python files pep 8-compliant
 fix-style:
-	pip3 install -r requirements/dev.txt -U
-	isort -rc $(MRLN)
-	isort -rc $(TEST)
-	isort *.py
-	black --target-version py36 $(MRLN)
-	black --target-version py36 $(TEST)
-	black --target-version py36 *.py
+	. $(VENV)/bin/activate; \
+	isort --line-length $(MAX_LINE_LENGTH) $(MRLN); \
+	isort --line-length $(MAX_LINE_LENGTH) $(TEST); \
+	isort --line-length $(MAX_LINE_LENGTH) *.py; \
+	black --target-version py36 -l $(MAX_LINE_LENGTH) $(MRLN); \
+	black --target-version py36 -l $(MAX_LINE_LENGTH) $(TEST); \
+	black --target-version py36 -l $(MAX_LINE_LENGTH) *.py; \
 
 
 # Increment the Merlin version. USE ONLY ON DEVELOP BEFORE MERGING TO MASTER.

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -64,9 +64,7 @@ try:
     LOG.debug("broker_ssl = %s", BROKER_SSL)
     RESULTS_BACKEND_URI = results_backend.get_connection_string()
     RESULTS_SSL = results_backend.get_ssl_config(celery_check=True)
-    LOG.debug(
-        "results: %s", results_backend.get_connection_string(include_password=False)
-    )
+    LOG.debug("results: %s", results_backend.get_connection_string(include_password=False))
     LOG.debug("results: redis_backed_use_ssl = %s", RESULTS_SSL)
 except ValueError:
     # These variables won't be set if running with '--local'.
@@ -141,11 +139,7 @@ def setup(**kwargs):  # pylint: disable=W0613
         process: psutil.Process = psutil.Process()
         # pylint is upset that typing accesses a protected class, ignoring W0212
         # pylint is upset that billiard doesn't have a current_process() method - it does
-        current: billiard.process._MainProcess = (
-            billiard.current_process()  # pylint: disable=W0212, E1101
-        )
-        prefork_id: int = (
-            current._identity[0] - 1  # pylint: disable=W0212
-        )  # range 0:nworkers-1
+        current: billiard.process._MainProcess = billiard.current_process()  # pylint: disable=W0212, E1101
+        prefork_id: int = current._identity[0] - 1  # pylint: disable=W0212  # range 0:nworkers-1
         cpu_slot: int = (prefork_id * cpu_skip) % npu
         process.cpu_affinity(list(range(cpu_slot, cpu_slot + cpu_skip)))

--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -106,12 +106,7 @@ def _get_npy_info2(f):
         hlen = hlen_char[0] + 256 * hlen_char[1]
     elif major == 2:
         hlen_char = list(map(ord, f.read(4)))
-        hlen = (
-            hlen_char[0]
-            + 256 * hlen_char[1]
-            + 65536 * hlen_char[2]
-            + (1 << 24) * hlen_char[3]
-        )
+        hlen = hlen_char[0] + 256 * hlen_char[1] + 65536 * hlen_char[2] + (1 << 24) * hlen_char[3]
     else:
         raise Exception("unknown .npy format, e.g. not 1 or 2")
     hdr = eval(f.read(hlen))  # TODO remove eval
@@ -135,12 +130,7 @@ def _get_npy_info3(f):
         hlen = hlen_char[0] + 256 * hlen_char[1]
     elif major == 2:
         hlen_char = list(f.read(4))
-        hlen = (
-            hlen_char[0]
-            + 256 * hlen_char[1]
-            + 65536 * hlen_char[2]
-            + (1 << 24) * hlen_char[3]
-        )
+        hlen = hlen_char[0] + 256 * hlen_char[1] + 65536 * hlen_char[2] + (1 << 24) * hlen_char[3]
     else:
         raise Exception("unknown .npy format, e.g. not 1 or 2")
     hdr = eval(f.read(hlen))  # TODO remove eval
@@ -186,9 +176,7 @@ def read_rows(f, hdr, idx, n=-1, sep=""):
     if n < 0:
         n = hdr["shape"][0] - idx
     n = min(hdr["shape"][0] - idx, n)
-    a = np.fromfile(
-        f, dtype=hdr["dtype"], count=n * hdr["rowsize"] // hdr["itemsize"], sep=sep
-    )
+    a = np.fromfile(f, dtype=hdr["dtype"], count=n * hdr["rowsize"] // hdr["itemsize"], sep=sep)
     return np.reshape(a, (n,) + hdr["shape"][1:])
 
 
@@ -216,9 +204,7 @@ class OpenNPY:
 
     def _verify_open(self):
         if self.f is None:
-            self.f, self.hdr = _get_npy_info(
-                self.f if self.f is not None else self.fname
-            )
+            self.f, self.hdr = _get_npy_info(self.f if self.f is not None else self.fname)
 
     @verify_open
     def load_header(self, close=True):
@@ -261,10 +247,7 @@ class OpenNPY:
                 return read_rows(self.f, self.hdr, k.start, k.stop - k.start)
             else:
                 return np.asarray(
-                    [
-                        read_rows(self.f, self.hdr, _, 1)[0]
-                        for _ in range(k.start, k.stop, 1 if k.step is None else k.step)
-                    ]
+                    [read_rows(self.f, self.hdr, _, 1)[0] for _ in range(k.start, k.stop, 1 if k.step is None else k.step)]
                 )
 
     @verify_open
@@ -288,19 +271,13 @@ class OpenNPYList:
         i: OpenNPY
         for i in self.files:
             i.load_header()
-        self.shapes: List[Tuple[int]] = [
-            openNPY_obj.hdr["shape"] for openNPY_obj in self.files
-        ]
+        self.shapes: List[Tuple[int]] = [openNPY_obj.hdr["shape"] for openNPY_obj in self.files]
         k: Tuple[int]
         for k in self.shapes[1:]:
             # Match subsequent axes shapes.
             if k[1:] != self.shapes[0][1:]:
-                raise AttributeError(
-                    f"Mismatch in subsequent axes shapes: {k[1:]} != {self.shapes[0][1:]}"
-                )
-        self.tells: np.ndarray = np.cumsum(
-            [arr_shape[0] for arr_shape in self.shapes]
-        )  # Tell locations.
+                raise AttributeError(f"Mismatch in subsequent axes shapes: {k[1:]} != {self.shapes[0][1:]}")
+        self.tells: np.ndarray = np.cumsum([arr_shape[0] for arr_shape in self.shapes])  # Tell locations.
         self.tells = np.hstack(([0], self.tells))
 
     def close(self):
@@ -325,14 +302,7 @@ class OpenNPYList:
             return self.files[fno - 1][k - self.tells[fno - 1]]
         else:  # Slice indexing.
             # TODO : Implement a faster version.
-            return np.asarray(
-                [
-                    self[_]
-                    for _ in np.arange(
-                        k.start, k.stop, k.step if k.step is not None else 1
-                    )
-                ]
-            )
+            return np.asarray([self[_] for _ in np.arange(k.start, k.stop, k.step if k.step is not None else 1)])
 
     def to_array(self):
         return np.vstack([_.to_array() for _ in self.files])

--- a/merlin/common/sample_index.py
+++ b/merlin/common/sample_index.py
@@ -69,9 +69,7 @@ class SampleIndex:
     # Class variable to indicate depth (mostly used for pretty printing).
     depth = -1
 
-    def __init__(
-        self, minid, maxid, children, name, leafid=-1, num_bundles=0, address=""
-    ):
+    def __init__(self, minid, maxid, children, name, leafid=-1, num_bundles=0, address=""):
         """The constructor."""
 
         # The direct children of this node, generally also of type SampleIndex.
@@ -140,9 +138,7 @@ class SampleIndex:
                 return True
         return False
 
-    def traverse(
-        self, path=None, conditional=lambda c: True, bottom_up=True, top_level=True
-    ):
+    def traverse(self, path=None, conditional=lambda c: True, bottom_up=True, top_level=True):
         """
         Yield the full path and associated node for each node that meets the
         conditional
@@ -164,9 +160,7 @@ class SampleIndex:
 
         for child_val in self.children.values():
             child_path = os.path.join(path, child_val.name)
-            for node in child_val.traverse(
-                child_path, conditional, bottom_up=bottom_up, top_level=False
-            ):
+            for node in child_val.traverse(child_path, conditional, bottom_up=bottom_up, top_level=False):
                 if node != "SKIP ME":
                     yield node
 
@@ -181,9 +175,7 @@ class SampleIndex:
         """
         Returns a generator that will traverse all nodes in the SampleIndex.
         """
-        return self.traverse(
-            path=self.name, conditional=lambda c: True, bottom_up=bottom_up
-        )
+        return self.traverse(path=self.name, conditional=lambda c: True, bottom_up=bottom_up)
 
     def traverse_bundles(self):
         """
@@ -197,9 +189,7 @@ class SampleIndex:
         Returns a generator that will traverse all Directories in the
         SampleIndex.
         """
-        return self.traverse(
-            path=self.name, conditional=lambda c: c.is_directory, bottom_up=bottom_up
-        )
+        return self.traverse(path=self.name, conditional=lambda c: c.is_directory, bottom_up=bottom_up)
 
     @staticmethod
     def check_valid_addresses_for_insertion(full_address, sub_tree):
@@ -293,9 +283,7 @@ class SampleIndex:
         if filepath is not None:
             filepaths.append(filepath)
         for child_val in self.children.values():
-            filepaths += child_val.write_multiple_sample_index_files(
-                os.path.join(path, self.name)
-            )
+            filepaths += child_val.write_multiple_sample_index_files(os.path.join(path, self.name))
         return filepaths
 
     def make_directory_string(self, delimiter=" ", just_leaf_directories=True):
@@ -312,28 +300,18 @@ class SampleIndex:
 
         """
         if just_leaf_directories:
-            return delimiter.join(
-                [
-                    path
-                    for path, node in self.traverse_directories()
-                    if node.is_parent_of_leaf
-                ]
-            )
+            return delimiter.join([path for path, node in self.traverse_directories() if node.is_parent_of_leaf])
         return delimiter.join([path for path, _ in self.traverse_directories()])
 
     def __str__(self):
         """String representation."""
         SampleIndex.depth = SampleIndex.depth + 1
         if self.is_leaf:
-            result = (
-                ("   " * SampleIndex.depth)
-                + f"{self.address}: BUNDLE {self.leafid} MIN {self.min} MAX {self.max}\n"
-            )
+            result = ("   " * SampleIndex.depth) + f"{self.address}: BUNDLE {self.leafid} MIN {self.min} MAX {self.max}\n"
         else:
             result = (
-                ("   " * SampleIndex.depth)
-                + f"{self.address}: DIRECTORY MIN {self.min} MAX {self.max} NUM_BUNDLES {self.num_bundles}\n"
-            )
+                "   " * SampleIndex.depth
+            ) + f"{self.address}: DIRECTORY MIN {self.min} MAX {self.max} NUM_BUNDLES {self.num_bundles}\n"
             for child_val in self.children.values():
                 result += str(child_val)
         SampleIndex.depth = SampleIndex.depth - 1

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -150,9 +150,7 @@ def create_hierarchy_from_max_sample(
             bundle_id += 1
         child_id += 1
     num_bundles = bundle_id - start_bundle_id
-    return SampleIndex(
-        min_sample, max_sample, children, root, num_bundles=num_bundles, address=address
-    )
+    return SampleIndex(min_sample, max_sample, children, root, num_bundles=num_bundles, address=address)
 
 
 def read_hierarchy(path):
@@ -167,9 +165,7 @@ def read_hierarchy(path):
         with open("sample_index.txt", "r") as _file:
             token = _file.readline()
             while token:
-                parsed_token = parse(
-                    "{type}:{ID}\tname:{name}\tsamples:[{min:d},{max:d})\n", token
-                )
+                parsed_token = parse("{type}:{ID}\tname:{name}\tsamples:[{min:d},{max:d})\n", token)
                 if parsed_token["type"] == "DIR":
                     subhierarchy = read_hierarchy(parsed_token["name"])
                     subhierarchy.address = parsed_token["ID"]
@@ -187,7 +183,5 @@ def read_hierarchy(path):
                 min_sample = min(min_sample, parsed_token["min"])
                 max_sample = max(max_sample, parsed_token["max"])
                 token = _file.readline()
-    top_index = SampleIndex(
-        min_sample, max_sample, children, path, leafid=-1, num_bundles=num_bundles
-    )
+    top_index = SampleIndex(min_sample, max_sample, children, path, leafid=-1, num_bundles=num_bundles)
     return top_index

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -92,9 +92,7 @@ def get_rabbit_connection(config_path, include_password, conn="amqps"):
     try:
         password = read_file(password_filepath)
     except IOError:
-        raise ValueError(
-            f"Broker: RabbitMQ password file {password_filepath} does not exist"
-        )
+        raise ValueError(f"Broker: RabbitMQ password file {password_filepath} does not exist")
 
     try:
         port = CONFIG.broker.port

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -195,9 +195,7 @@ def get_cert_file(server_type, config, cert_name, cert_path):
             if os.path.exists(new_cert_file):
                 cert_file = new_cert_file
             else:
-                LOG.error(
-                    f"{server_type}: The file for {cert_name} does not exist, searched {cert_file} and {new_cert_file}"
-                )
+                LOG.error(f"{server_type}: The file for {cert_name} does not exist, searched {cert_file} and {new_cert_file}")
         LOG.debug(f"{server_type}: {cert_name} = {cert_file}")
     except (AttributeError, KeyError):
         LOG.debug(f"{server_type}: {cert_name} not present")
@@ -220,21 +218,15 @@ def get_ssl_entries(
     """
     server_ssl: Dict[str, Union[str, ssl.VerifyMode]] = {}
 
-    keyfile: Optional[str] = get_cert_file(
-        server_type, server_config, "keyfile", cert_path
-    )
+    keyfile: Optional[str] = get_cert_file(server_type, server_config, "keyfile", cert_path)
     if keyfile:
         server_ssl["keyfile"] = keyfile
 
-    certfile: Optional[str] = get_cert_file(
-        server_type, server_config, "certfile", cert_path
-    )
+    certfile: Optional[str] = get_cert_file(server_type, server_config, "certfile", cert_path)
     if certfile:
         server_ssl["certfile"] = certfile
 
-    ca_certsfile: Optional[str] = get_cert_file(
-        server_type, server_config, "ca_certs", cert_path
-    )
+    ca_certsfile: Optional[str] = get_cert_file(server_type, server_config, "ca_certs", cert_path)
     if ca_certsfile:
         server_ssl["ca_certs"] = ca_certsfile
 
@@ -289,9 +281,7 @@ def process_ssl_map(server_name: str) -> Optional[Dict[str, str]]:
     return ssl_map
 
 
-def merge_sslmap(
-    server_ssl: Dict[str, Union[str, ssl.VerifyMode]], ssl_map: Dict[str, str]
-) -> Dict:
+def merge_sslmap(server_ssl: Dict[str, Union[str, ssl.VerifyMode]], ssl_map: Dict[str, str]) -> Dict:
     """
     The different servers have different key var expectations, this updates the keys of the ssl_server dict with keys from
     the ssl_map if using rediss or mysql.

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -60,10 +60,7 @@ MYSQL_CONFIG_FILENAMES = {
 
 
 MYSQL_CONNECTION_STRING = (
-    "db+mysql+mysqldb://{user}:{password}@{server}/mlsi"
-    "?ssl_ca={ssl_ca}"
-    "&ssl_cert={ssl_cert}"
-    "&ssl_key={ssl_key}"
+    "db+mysql+mysqldb://{user}:{password}@{server}/mlsi" "?ssl_ca={ssl_ca}" "&ssl_cert={ssl_cert}" "&ssl_key={ssl_key}"
 )
 
 
@@ -280,9 +277,7 @@ def _resolve_backend_string(backend, certs_path, include_password):
         return get_redis(certs_path=certs_path, include_password=include_password)
 
     elif backend == "rediss":
-        return get_redis(
-            certs_path=certs_path, include_password=include_password, ssl=True
-        )
+        return get_redis(certs_path=certs_path, include_password=include_password, ssl=True)
     else:
         return None
 
@@ -313,9 +308,7 @@ def get_ssl_config(celery_check=False):
     except AttributeError:
         certs_path = None
 
-    results_backend_ssl = get_ssl_entries(
-        "Results Backend", results_backend, CONFIG.results_backend, certs_path
-    )
+    results_backend_ssl = get_ssl_entries("Results Backend", results_backend, CONFIG.results_backend, certs_path)
 
     if results_backend == "rediss":
         if not results_backend_ssl:

--- a/merlin/config/utils.py
+++ b/merlin/config/utils.py
@@ -22,9 +22,7 @@ def get_priority(priority: Priority) -> int:
     broker: str = CONFIG.broker.name.lower()
     priorities: List[Priority] = [Priority.high, Priority.mid, Priority.low]
     if not isinstance(priority, Priority):
-        raise TypeError(
-            f"Unrecognized priority '{priority}'! Priority enum options: {[x.name for x in priorities]}"
-        )
+        raise TypeError(f"Unrecognized priority '{priority}'! Priority enum options: {[x.name for x in priorities]}")
     if priority == Priority.mid:
         return 5
     if is_rabbit_broker(broker):
@@ -37,6 +35,4 @@ def get_priority(priority: Priority) -> int:
             return 10
         if priority == Priority.high:
             return 1
-    raise ValueError(
-        f"Function get_priority has reached unknown state! Maybe unsupported broker {broker}?"
-    )
+    raise ValueError(f"Function get_priority has reached unknown state! Maybe unsupported broker {broker}?")

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -97,9 +97,7 @@ def _examine_connection(s, sconf, excpts):
             counter += 1
             if counter > connect_timeout:
                 conn_check.kill()
-                raise Exception(
-                    f"Connection was killed due to timeout ({connect_timeout}s)"
-                )
+                raise Exception(f"Connection was killed due to timeout ({connect_timeout}s)")
         conn.release()
         if conn_check.exception:
             error, traceback = conn_check.exception
@@ -131,9 +129,7 @@ def display_config_info():
         excpts["broker server"] = e
 
     try:
-        conf["results server"] = results_backend.get_connection_string(
-            include_password=False
-        )
+        conf["results server"] = results_backend.get_connection_string(include_password=False)
         sconf["results server"] = results_backend.get_connection_string()
         conf["results ssl"] = results_backend.get_ssl_config()
     except Exception as e:

--- a/merlin/examples/workflows/feature_demo/scripts/hello_world.py
+++ b/merlin/examples/workflows/feature_demo/scripts/hello_world.py
@@ -18,18 +18,10 @@ def process_args(args):
 
 def setup_argparse():
     parser = argparse.ArgumentParser(description="Process some integers.")
-    parser.add_argument(
-        "X", metavar="X", type=float, help="The x dimension of the sample."
-    )
-    parser.add_argument(
-        "Y", metavar="Y", type=float, help="The y dimension of the sample."
-    )
-    parser.add_argument(
-        "Z", metavar="Z", type=float, help="The z dimension of the sample."
-    )
-    parser.add_argument(
-        "-outfile", help="Output file name", default="hello_world_output.json"
-    )
+    parser.add_argument("X", metavar="X", type=float, help="The x dimension of the sample.")
+    parser.add_argument("Y", metavar="Y", type=float, help="The y dimension of the sample.")
+    parser.add_argument("Z", metavar="Z", type=float, help="The z dimension of the sample.")
+    parser.add_argument("-outfile", help="Output file name", default="hello_world_output.json")
     return parser
 
 

--- a/merlin/examples/workflows/hello/make_samples.py
+++ b/merlin/examples/workflows/hello/make_samples.py
@@ -6,9 +6,7 @@ import numpy as np
 
 # argument parsing
 parser = argparse.ArgumentParser(description="Make some samples (names of people).")
-parser.add_argument(
-    "--number", type=int, action="store", help="the number of samples you want to make"
-)
+parser.add_argument("--number", type=int, action="store", help="the number of samples you want to make")
 parser.add_argument("--filepath", type=str, help="output file")
 args = parser.parse_args()
 

--- a/merlin/examples/workflows/hpc_demo/cumulative_sample_processor.py
+++ b/merlin/examples/workflows/hpc_demo/cumulative_sample_processor.py
@@ -37,29 +37,20 @@ def iter_df_from_json(json_file):
 def load_samples(sample_file_paths, nproc):
     """Loads all iterations' processed samples into a single pandas DataFrame in parallel"""
     with ProcessPoolExecutor(max_workers=nproc) as executor:
-        iter_dfs = [
-            iter_frame
-            for iter_frame in executor.map(iter_df_from_json, sample_file_paths)
-        ]
+        iter_dfs = [iter_frame for iter_frame in executor.map(iter_df_from_json, sample_file_paths)]
     all_iter_df = pd.concat(iter_dfs)
 
     return all_iter_df
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in and analyze samples from plain text file"
-    )
+    parser = argparse.ArgumentParser(description="Read in and analyze samples from plain text file")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample files", default="", nargs="+")
 
     parser.add_argument("--np", help="number of processors to use", type=int, default=1)
 
-    parser.add_argument(
-        "--hardcopy", help="Name of cumulative plot file", default="cum_results.png"
-    )
+    parser.add_argument("--hardcopy", help="Name of cumulative plot file", default="cum_results.png")
 
     return parser
 
@@ -89,9 +80,7 @@ def main():
         min_counts.append(all_iter_df[all_iter_df["Iter"] <= it]["Count"].min())
         med_counts.append(all_iter_df[all_iter_df["Iter"] <= it]["Count"].median())
 
-        unique_names.append(
-            len(all_iter_df[all_iter_df["Iter"] <= it].index.value_counts())
-        )
+        unique_names.append(len(all_iter_df[all_iter_df["Iter"] <= it].index.value_counts()))
 
     ax[0].plot(iterations, min_counts, label="Minimum Occurances")
     ax[0].plot(iterations, max_counts, label="Maximum Occurances")

--- a/merlin/examples/workflows/hpc_demo/faker_sample.py
+++ b/merlin/examples/workflows/hpc_demo/faker_sample.py
@@ -27,9 +27,7 @@ def setup_argparse():
     parser = argparse.ArgumentParser("Generate some names!")
     parser.add_argument("-n", help="number of names", default=100, type=int)
     parser.add_argument("-b", help="number of batches of names", default=5, type=int)
-    parser.add_argument(
-        "-outfile", help="name of output .csv file", default="samples.csv"
-    )
+    parser.add_argument("-outfile", help="name of output .csv file", default="samples.csv")
     return parser
 
 

--- a/merlin/examples/workflows/hpc_demo/sample_collector.py
+++ b/merlin/examples/workflows/hpc_demo/sample_collector.py
@@ -18,11 +18,7 @@ def load_samples(sample_file_path):
 def serialize_samples(sample_file_paths, outfile, nproc):
     """Writes out collection of samples, one entry per line"""
     with ProcessPoolExecutor(max_workers=nproc) as executor:
-        all_samples = [
-            sample
-            for sample_list in executor.map(load_samples, sample_file_paths)
-            for sample in sample_list
-        ]
+        all_samples = [sample for sample_list in executor.map(load_samples, sample_file_paths) for sample in sample_list]
 
     with open(outfile, "w") as outfile:
         for sample in all_samples:
@@ -30,19 +26,13 @@ def serialize_samples(sample_file_paths, outfile, nproc):
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in samples from list of output files"
-    )
+    parser = argparse.ArgumentParser(description="Read in samples from list of output files")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample output files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample output files", default="", nargs="+")
 
     parser.add_argument("--np", help="number of processors to use", type=int, default=1)
 
-    parser.add_argument(
-        "-outfile", help="Collected sample outputs", default="all_names.txt"
-    )
+    parser.add_argument("-outfile", help="Collected sample outputs", default="all_names.txt")
     return parser
 
 

--- a/merlin/examples/workflows/hpc_demo/sample_processor.py
+++ b/merlin/examples/workflows/hpc_demo/sample_processor.py
@@ -19,17 +19,11 @@ def load_samples(sample_file_paths):
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in and analyze samples from plain text file"
-    )
+    parser = argparse.ArgumentParser(description="Read in and analyze samples from plain text file")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample files", default="", nargs="+")
 
-    parser.add_argument(
-        "--results", help="Name of output json file", default="samples.json"
-    )
+    parser.add_argument("--results", help="Name of output json file", default="samples.json")
 
     return parser
 

--- a/merlin/examples/workflows/iterative_demo/cumulative_sample_processor.py
+++ b/merlin/examples/workflows/iterative_demo/cumulative_sample_processor.py
@@ -37,29 +37,20 @@ def iter_df_from_json(json_file):
 def load_samples(sample_file_paths, nproc):
     """Loads all iterations' processed samples into a single pandas DataFrame in parallel"""
     with ProcessPoolExecutor(max_workers=nproc) as executor:
-        iter_dfs = [
-            iter_frame
-            for iter_frame in executor.map(iter_df_from_json, sample_file_paths)
-        ]
+        iter_dfs = [iter_frame for iter_frame in executor.map(iter_df_from_json, sample_file_paths)]
     all_iter_df = pd.concat(iter_dfs)
 
     return all_iter_df
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in and analyze samples from plain text file"
-    )
+    parser = argparse.ArgumentParser(description="Read in and analyze samples from plain text file")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample files", default="", nargs="+")
 
     parser.add_argument("--np", help="number of processors to use", type=int, default=1)
 
-    parser.add_argument(
-        "--hardcopy", help="Name of cumulative plot file", default="cum_results.png"
-    )
+    parser.add_argument("--hardcopy", help="Name of cumulative plot file", default="cum_results.png")
 
     return parser
 
@@ -89,9 +80,7 @@ def main():
         min_counts.append(all_iter_df[all_iter_df["Iter"] <= it]["Count"].min())
         med_counts.append(all_iter_df[all_iter_df["Iter"] <= it]["Count"].median())
 
-        unique_names.append(
-            len(all_iter_df[all_iter_df["Iter"] <= it].index.value_counts())
-        )
+        unique_names.append(len(all_iter_df[all_iter_df["Iter"] <= it].index.value_counts()))
 
     ax[0].plot(iterations, min_counts, label="Minimum Occurances")
     ax[0].plot(iterations, max_counts, label="Maximum Occurances")

--- a/merlin/examples/workflows/iterative_demo/faker_sample.py
+++ b/merlin/examples/workflows/iterative_demo/faker_sample.py
@@ -27,9 +27,7 @@ def setup_argparse():
     parser = argparse.ArgumentParser("Generate some names!")
     parser.add_argument("-n", help="number of names", default=100, type=int)
     parser.add_argument("-b", help="number of batches of names", default=5, type=int)
-    parser.add_argument(
-        "-outfile", help="name of output .csv file", default="samples.csv"
-    )
+    parser.add_argument("-outfile", help="name of output .csv file", default="samples.csv")
     return parser
 
 

--- a/merlin/examples/workflows/iterative_demo/sample_collector.py
+++ b/merlin/examples/workflows/iterative_demo/sample_collector.py
@@ -18,11 +18,7 @@ def load_samples(sample_file_path):
 def serialize_samples(sample_file_paths, outfile, nproc):
     """Writes out collection of samples, one entry per line"""
     with ProcessPoolExecutor(max_workers=nproc) as executor:
-        all_samples = [
-            sample
-            for sample_list in executor.map(load_samples, sample_file_paths)
-            for sample in sample_list
-        ]
+        all_samples = [sample for sample_list in executor.map(load_samples, sample_file_paths) for sample in sample_list]
 
     with open(outfile, "w") as outfile:
         for sample in all_samples:
@@ -30,19 +26,13 @@ def serialize_samples(sample_file_paths, outfile, nproc):
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in samples from list of output files"
-    )
+    parser = argparse.ArgumentParser(description="Read in samples from list of output files")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample output files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample output files", default="", nargs="+")
 
     parser.add_argument("--np", help="number of processors to use", type=int, default=1)
 
-    parser.add_argument(
-        "-outfile", help="Collected sample outputs", default="all_names.txt"
-    )
+    parser.add_argument("-outfile", help="Collected sample outputs", default="all_names.txt")
     return parser
 
 

--- a/merlin/examples/workflows/iterative_demo/sample_processor.py
+++ b/merlin/examples/workflows/iterative_demo/sample_processor.py
@@ -19,17 +19,11 @@ def load_samples(sample_file_paths):
 
 
 def setup_argparse():
-    parser = argparse.ArgumentParser(
-        description="Read in and analyze samples from plain text file"
-    )
+    parser = argparse.ArgumentParser(description="Read in and analyze samples from plain text file")
 
-    parser.add_argument(
-        "sample_file_paths", help="paths to sample files", default="", nargs="+"
-    )
+    parser.add_argument("sample_file_paths", help="paths to sample files", default="", nargs="+")
 
-    parser.add_argument(
-        "--results", help="Name of output json file", default="samples.json"
-    )
+    parser.add_argument("--results", help="Name of output json file", default="samples.json")
 
     return parser
 

--- a/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
+++ b/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
@@ -6,9 +6,7 @@ import subprocess
 from typing import List
 
 
-parser: argparse.ArgumentParser = argparse.ArgumentParser(
-    description="Launch 35 merlin workflow jobs"
-)
+parser: argparse.ArgumentParser = argparse.ArgumentParser(description="Launch 35 merlin workflow jobs")
 parser.add_argument("run_id", type=int, help="The ID of this run")
 parser.add_argument("output_path", type=str, help="the output path")
 parser.add_argument("spec_path", type=str, help="path to the spec to run")

--- a/merlin/examples/workflows/null_spec/scripts/make_samples.py
+++ b/merlin/examples/workflows/null_spec/scripts/make_samples.py
@@ -5,12 +5,8 @@ import numpy as np
 
 # argument parsing
 parser = argparse.ArgumentParser(description="Make some samples (names of people).")
-parser.add_argument(
-    "--number", type=int, action="store", help="the number of samples you want to make"
-)
-parser.add_argument(
-    "--filepath", type=str, default="samples_file.npy", help="output file"
-)
+parser.add_argument("--number", type=int, action="store", help="the number of samples you want to make")
+parser.add_argument("--filepath", type=str, default="samples_file.npy", help="output file")
 args = parser.parse_args()
 
 # sample making

--- a/merlin/examples/workflows/null_spec/scripts/read_output.py
+++ b/merlin/examples/workflows/null_spec/scripts/read_output.py
@@ -31,9 +31,7 @@ def single_task_times():
     task_durations = []
     for log in args.logfile:
         try:
-            pre_lines = subprocess.check_output(
-                f'grep " succeeded in " {log}', shell=True
-            ).decode("ascii")
+            pre_lines = subprocess.check_output(f'grep " succeeded in " {log}', shell=True).decode("ascii")
 
             pre_list = pre_lines.strip().split("\n")
 
@@ -52,9 +50,7 @@ def single_task_times():
 def merlin_run_time():
     total = 0
     for err in args.errfile:
-        pre_line = subprocess.check_output(f'grep "real" {err}', shell=True).decode(
-            "ascii"
-        )
+        pre_line = subprocess.check_output(f'grep "real" {err}', shell=True).decode("ascii")
         pre_line = pre_line.strip()
         matches = re.search(r"\d\.\d\d\d", pre_line)
         match = matches[0]
@@ -64,18 +60,14 @@ def merlin_run_time():
         print(f"c{args.c}_s{args.s} merlin run : " + str(result))
     except BaseException:
         result = None
-        print(
-            f"c{args.c}_s{args.s} merlin run : ERROR -- result={result}, args.errfile={args.errfile}"
-        )
+        print(f"c{args.c}_s{args.s} merlin run : ERROR -- result={result}, args.errfile={args.errfile}")
 
 
 def start_verify_time():
     all_timestamps = []
     for log in args.logfile:
         try:
-            pre_line = subprocess.check_output(
-                f'grep -m1 "verify" {log}', shell=True
-            ).decode("ascii")
+            pre_line = subprocess.check_output(f'grep -m1 "verify" {log}', shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]
@@ -94,9 +86,7 @@ def start_run_workers_time():
     all_timestamps = []
     for log in args.logfile:
         try:
-            pre_line = subprocess.check_output(f'grep -m1 "" {log}', shell=True).decode(
-                "ascii"
-            )
+            pre_line = subprocess.check_output(f'grep -m1 "" {log}', shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]
@@ -113,9 +103,7 @@ def start_sample1_time():
     all_timestamps = []
     for log in args.logfile:
         try:
-            pre_line = subprocess.check_output(
-                f"grep -m1 \"Executing step 'null_step'\" {log}", shell=True
-            ).decode("ascii")
+            pre_line = subprocess.check_output(f"grep -m1 \"Executing step 'null_step'\" {log}", shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]

--- a/merlin/examples/workflows/null_spec/scripts/read_output_chain.py
+++ b/merlin/examples/workflows/null_spec/scripts/read_output_chain.py
@@ -43,9 +43,7 @@ def single_task_times():
     for k, v in logmap.items():
         task_durations = []
         try:
-            pre_lines = subprocess.check_output(
-                f'grep " succeeded in " {v}', shell=True
-            ).decode("ascii")
+            pre_lines = subprocess.check_output(f'grep " succeeded in " {v}', shell=True).decode("ascii")
 
             pre_list = pre_lines.strip().split("\n")
 
@@ -65,9 +63,7 @@ def single_task_times():
 def merlin_run_time():
     total = 0
     for err in args.errfile:
-        pre_line = subprocess.check_output(f'grep "real" {err}', shell=True).decode(
-            "ascii"
-        )
+        pre_line = subprocess.check_output(f'grep "real" {err}', shell=True).decode("ascii")
         pre_line = pre_line.strip()
         matches = re.search(r"\d\.\d\d\d", pre_line)
         match = matches[0]
@@ -77,18 +73,14 @@ def merlin_run_time():
         print(f"c{filled_c} merlin run : " + str(result))
     except BaseException:
         result = None
-        print(
-            f"c{filled_c} merlin run : ERROR -- result={result}, args.errfile={args.errfile}"
-        )
+        print(f"c{filled_c} merlin run : ERROR -- result={result}, args.errfile={args.errfile}")
 
 
 def start_verify_time():
     for k, v in logmap.items():
         all_timestamps = []
         try:
-            pre_line = subprocess.check_output(
-                f'grep -m2 "verify" {v} | tail -n1', shell=True
-            ).decode("ascii")
+            pre_line = subprocess.check_output(f'grep -m2 "verify" {v} | tail -n1', shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]
@@ -108,9 +100,7 @@ def start_run_workers_time():
     for k, v in logmap.items():
         all_timestamps = []
         try:
-            pre_line = subprocess.check_output(f'grep -m1 "" {v}', shell=True).decode(
-                "ascii"
-            )
+            pre_line = subprocess.check_output(f'grep -m1 "" {v}', shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]
@@ -127,9 +117,7 @@ def start_sample1_time():
     for k, v in logmap.items():
         all_timestamps = []
         try:
-            pre_line = subprocess.check_output(
-                f"grep -m1 \"Executing step 'null_step'\" {v}", shell=True
-            ).decode("ascii")
+            pre_line = subprocess.check_output(f"grep -m1 \"Executing step 'null_step'\" {v}", shell=True).decode("ascii")
             pre_line = pre_line.strip()
             matches = re.search(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d", pre_line)
             match = matches[0]

--- a/merlin/examples/workflows/openfoam_wf/scripts/combine_outputs.py
+++ b/merlin/examples/workflows/openfoam_wf/scripts/combine_outputs.py
@@ -8,9 +8,7 @@ import Ofpp
 descript = """Using parameters to edit OpenFOAM parameters"""
 parser = argparse.ArgumentParser(description=descript)
 
-parser.add_argument(
-    "-data", "--data_dir", help="The home directory of the data directories"
-)
+parser.add_argument("-data", "--data_dir", help="The home directory of the data directories")
 parser.add_argument("-merlin_paths", nargs="+", help="The path of all merlin runs")
 
 args = parser.parse_args()
@@ -37,8 +35,6 @@ for i, dir_name in enumerate(dir_names):
 
 resolution = np.array(enstrophy).shape[-1]
 U = np.array(U).reshape(len(dir_names), num_of_timesteps, resolution, 3)
-enstrophy = np.array(enstrophy).reshape(
-    len(dir_names), num_of_timesteps, resolution
-) / float(resolution)
+enstrophy = np.array(enstrophy).reshape(len(dir_names), num_of_timesteps, resolution) / float(resolution)
 
 np.savez("data.npz", U, enstrophy)

--- a/merlin/examples/workflows/openfoam_wf/scripts/make_samples.py
+++ b/merlin/examples/workflows/openfoam_wf/scripts/make_samples.py
@@ -22,8 +22,6 @@ x = np.empty((N_SAMPLES, 2))
 x[:, 0] = np.random.uniform(LIDSPEED_RANGE[0], LIDSPEED_RANGE[1], size=N_SAMPLES)
 vi_low = np.log10(x[:, 0] / REYNOLD_RANGE[1])
 vi_high = np.log10(x[:, 0] / REYNOLD_RANGE[0])
-x[:, 1] = [
-    loguniform(low=vi_low[i], high=vi_high[i], base=BASE) for i in range(N_SAMPLES)
-]
+x[:, 1] = [loguniform(low=vi_low[i], high=vi_high[i], base=BASE) for i in range(N_SAMPLES)]
 
 np.save(args.outfile, x)

--- a/merlin/examples/workflows/openfoam_wf_no_docker/scripts/combine_outputs.py
+++ b/merlin/examples/workflows/openfoam_wf_no_docker/scripts/combine_outputs.py
@@ -8,9 +8,7 @@ import Ofpp
 descript = """Using parameters to edit OpenFOAM parameters"""
 parser = argparse.ArgumentParser(description=descript)
 
-parser.add_argument(
-    "-data", "--data_dir", help="The home directory of the data directories"
-)
+parser.add_argument("-data", "--data_dir", help="The home directory of the data directories")
 parser.add_argument("-merlin_paths", nargs="+", help="The path of all merlin runs")
 
 args = parser.parse_args()
@@ -37,8 +35,6 @@ for i, dir_name in enumerate(dir_names):
 
 resolution = np.array(enstrophy).shape[-1]
 U = np.array(U).reshape(len(dir_names), num_of_timesteps, resolution, 3)
-enstrophy = np.array(enstrophy).reshape(
-    len(dir_names), num_of_timesteps, resolution
-) / float(resolution)
+enstrophy = np.array(enstrophy).reshape(len(dir_names), num_of_timesteps, resolution) / float(resolution)
 
 np.savez("data.npz", U, enstrophy)

--- a/merlin/examples/workflows/openfoam_wf_no_docker/scripts/make_samples.py
+++ b/merlin/examples/workflows/openfoam_wf_no_docker/scripts/make_samples.py
@@ -22,8 +22,6 @@ x = np.empty((N_SAMPLES, 2))
 x[:, 0] = np.random.uniform(LIDSPEED_RANGE[0], LIDSPEED_RANGE[1], size=N_SAMPLES)
 vi_low = np.log10(x[:, 0] / REYNOLD_RANGE[1])
 vi_high = np.log10(x[:, 0] / REYNOLD_RANGE[0])
-x[:, 1] = [
-    loguniform(low=vi_low[i], high=vi_high[i], base=BASE) for i in range(N_SAMPLES)
-]
+x[:, 1] = [loguniform(low=vi_low[i], high=vi_high[i], base=BASE) for i in range(N_SAMPLES)]
 
 np.save(args.outfile, x)

--- a/merlin/examples/workflows/optimization/scripts/optimizer.py
+++ b/merlin/examples/workflows/optimization/scripts/optimizer.py
@@ -13,12 +13,8 @@ parser.add_argument(
     "-learner_dir",
     help="Learner directory (joblib file), usually '$(learner.workspace)'",
 )
-parser.add_argument(
-    "-bounds", help="ranges to scale results in form '[(min,max,type),(min, max,type)]'"
-)
-parser.add_argument(
-    "-input_uncerts", help="The standard deviation for each input dimension"
-)
+parser.add_argument("-bounds", help="ranges to scale results in form '[(min,max,type),(min, max,type)]'")
+parser.add_argument("-input_uncerts", help="The standard deviation for each input dimension")
 parser.add_argument("-method", help="The optimizer method", default="trust-constr")
 
 args = parser.parse_args()
@@ -66,9 +62,7 @@ def get_x_deltas(x_std=None, n_samples=500):
         return 0
     else:
         x_cov = np.asarray(x_std) ** 2
-        x_deltas = multivariate_normal.rvs(
-            np.zeros(x_cov.shape), cov=x_cov, size=n_samples
-        )
+        x_deltas = multivariate_normal.rvs(np.zeros(x_cov.shape), cov=x_cov, size=n_samples)
         return x_deltas
 
 
@@ -119,9 +113,7 @@ best_f_i = existing_f.argmin()  # min value because minimize!
 best_f_x = existing_X[best_f_i]
 
 old_y_mean, old_y_std = mean_and_std(best_f_x, surrogate, x_deltas)
-old_y_percentiles = prediction_percentile(
-    best_f_x, surrogate, x_deltas, eval_percents
-).tolist()
+old_y_percentiles = prediction_percentile(best_f_x, surrogate, x_deltas, eval_percents).tolist()
 
 delta_mults = [0.0, 0.5, 1.0, 1.5, 2.0]
 x_deltas_big = {}
@@ -133,9 +125,7 @@ for d in x_deltas_big:
     x_samples_big = best_f_x + x_deltas_big[d]
     y_samples_big = surrogate.predict(x_samples_big)
     best_point_variations[d] = {}
-    best_point_variations[d]["percentiles"] = np.percentile(
-        y_samples_big, eval_percents
-    ).tolist()
+    best_point_variations[d]["percentiles"] = np.percentile(y_samples_big, eval_percents).tolist()
 
     counts, bins = np.histogram(y_samples_big, bins=20)
     best_point_variations[d]["histogram_counts"] = counts.tolist()
@@ -156,9 +146,7 @@ init_x = x0.tolist()
 init_y = (start_f).tolist()
 
 opt_y_mean, opt_y_std = mean_and_std(optimum_func.x, surrogate, x_deltas)
-opt_y_percentiles = prediction_percentile(
-    optimum_func.x, surrogate, x_deltas, eval_percents
-).tolist()
+opt_y_percentiles = prediction_percentile(optimum_func.x, surrogate, x_deltas, eval_percents).tolist()
 
 results = {
     "Results": {

--- a/merlin/examples/workflows/optimization/scripts/visualizer.py
+++ b/merlin/examples/workflows/optimization/scripts/visualizer.py
@@ -8,9 +8,7 @@ from joblib import load
 plt.style.use("seaborn-white")
 
 parser = argparse.ArgumentParser("Learn surrogate model form simulation")
-parser.add_argument(
-    "-study_dir", help="The study directory, usually '$(MERLIN_WORKSPACE)'"
-)
+parser.add_argument("-study_dir", help="The study directory, usually '$(MERLIN_WORKSPACE)'")
 args = parser.parse_args()
 
 study_dir = args.study_dir
@@ -19,9 +17,7 @@ learner_path = f"{study_dir}/learner/surrogate.joblib"
 new_samples_path = f"{study_dir}/pick_new_inputs/new_samples.npy"
 new_exploit_samples_path = f"{study_dir}/pick_new_inputs/new_exploit_samples.npy"
 new_explore_samples_path = f"{study_dir}/pick_new_inputs/new_explore_samples.npy"
-new_explore_star_samples_path = (
-    f"{study_dir}/pick_new_inputs/new_explore_star_samples.npy"
-)
+new_explore_star_samples_path = f"{study_dir}/pick_new_inputs/new_explore_star_samples.npy"
 optimum_path = f"{study_dir}/optimizer/optimum.npy"
 old_best_path = f"{study_dir}/optimizer/old_best.npy"
 
@@ -115,9 +111,7 @@ ax.plot_surface(
     alpha=0.4,
     edgecolor="none",
 )
-ax.scatter(
-    existing_X[:, 0], existing_X[:, 1], np.clip(existing_y, -100, 100), marker="x"
-)
+ax.scatter(existing_X[:, 0], existing_X[:, 1], np.clip(existing_y, -100, 100), marker="x")
 ax.view_init(45, 45)
 ax.set_xlabel("DIM_1")
 ax.set_ylabel("DIM_2")
@@ -134,9 +128,7 @@ ax.plot_surface(
     alpha=0.4,
     edgecolor="none",
 )
-ax.scatter(
-    existing_X[:, 0], existing_X[:, 1], np.clip(existing_y, -100, 100), marker="x"
-)
+ax.scatter(existing_X[:, 0], existing_X[:, 1], np.clip(existing_y, -100, 100), marker="x")
 ax.view_init(45, 45)
 ax.set_xlabel("DIM_1")
 ax.set_ylabel("DIM_2")
@@ -146,9 +138,7 @@ ax = fig.add_subplot(3, 2, 5)
 ax.scatter(existing_X[:, 0], existing_X[:, 1], label="Existing Inputs")
 ax.scatter(new_samples[:, 0], new_samples[:, 1], label="Suggested Inputs")
 ax.annotate("Predicted Optimum", xy=optimum, xytext=(1, 0), arrowprops=dict(width=0.01))
-ax.annotate(
-    "Current Best", xy=old_best, xytext=(-1.5, 1.5), arrowprops=dict(width=0.01)
-)
+ax.annotate("Current Best", xy=old_best, xytext=(-1.5, 1.5), arrowprops=dict(width=0.01))
 ax.annotate("Actual Minimum", xy=(1, 1), xytext=(1.5, 2.5), arrowprops=dict(width=0.01))
 
 ax.set_xlabel("DIM_1")
@@ -158,12 +148,8 @@ ax.legend()
 ax.grid()
 
 ax = fig.add_subplot(3, 2, 6)
-ax.scatter(
-    new_exploit_samples[:, 0], new_exploit_samples[:, 1], label="Exploit Samples"
-)
-ax.scatter(
-    new_explore_samples[:, 0], new_explore_samples[:, 1], label="Explore Samples"
-)
+ax.scatter(new_exploit_samples[:, 0], new_exploit_samples[:, 1], label="Exploit Samples")
+ax.scatter(new_explore_samples[:, 0], new_explore_samples[:, 1], label="Explore Samples")
 ax.scatter(
     new_explore_star_samples[:, 0],
     new_explore_star_samples[:, 1],

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -124,23 +124,15 @@ def parse_override_vars(
     for arg in variables_list:
         try:
             if "=" not in arg:
-                raise ValueError(
-                    "--vars requires '=' operator. See 'merlin run --help' for an example."
-                )
+                raise ValueError("--vars requires '=' operator. See 'merlin run --help' for an example.")
             entry: str = arg.split("=")
             if len(entry) != 2:
-                raise ValueError(
-                    "--vars requires ONE '=' operator (without spaces) per variable assignment."
-                )
+                raise ValueError("--vars requires ONE '=' operator (without spaces) per variable assignment.")
             key: str = entry[0]
             if key is None or key == "" or "$" in key:
-                raise ValueError(
-                    "--vars requires valid variable names comprised of alphanumeric characters and underscores."
-                )
+                raise ValueError("--vars requires valid variable names comprised of alphanumeric characters and underscores.")
             if key in RESERVED:
-                raise ValueError(
-                    f"Cannot override reserved word '{key}'! Reserved words are: {RESERVED}."
-                )
+                raise ValueError(f"Cannot override reserved word '{key}'! Reserved words are: {RESERVED}.")
 
             val: Union[str, int] = entry[1]
             with suppress(ValueError):
@@ -182,9 +174,7 @@ def process_run(args: Namespace) -> None:
 
     # pgen checks
     if args.pargs and not args.pgen_file:
-        raise ValueError(
-            "Cannot use the 'pargs' parameter without specifying a 'pgen'!"
-        )
+        raise ValueError("Cannot use the 'pargs' parameter without specifying a 'pgen'!")
     if args.pgen_file:
         verify_filepath(args.pgen_file)
 
@@ -211,13 +201,9 @@ def process_restart(args: Namespace) -> None:
     filepath: str = os.path.join(args.restart_dir, "merlin_info", "*.expanded.yaml")
     possible_specs: Optional[List[str]] = glob.glob(filepath)
     if not possible_specs:  # len == 0
-        raise ValueError(
-            f"'{filepath}' does not match any provenance spec file to restart from."
-        )
+        raise ValueError(f"'{filepath}' does not match any provenance spec file to restart from.")
     if len(possible_specs) > 1:
-        raise ValueError(
-            f"'{filepath}' matches more than one provenance spec file to restart from."
-        )
+        raise ValueError(f"'{filepath}' matches more than one provenance spec file to restart from.")
     filepath: str = verify_filepath(possible_specs[0])
     LOG.info(f"Restarting workflow at '{restart_dir}'")
     study: MerlinStudy = MerlinStudy(filepath, restart_dir=restart_dir)
@@ -235,9 +221,7 @@ def launch_workers(args):
     spec, filepath = get_merlin_spec_with_override(args)
     if not args.worker_echo_only:
         LOG.info(f"Launching workers from '{filepath}'")
-    status = router.launch_workers(
-        spec, args.worker_steps, args.worker_args, args.worker_echo_only
-    )
+    status = router.launch_workers(spec, args.worker_steps, args.worker_args, args.worker_echo_only)
     if args.worker_echo_only:
         print(status)
     else:
@@ -301,9 +285,7 @@ def stop_workers(args):
         worker_names = spec.get_worker_names()
         for worker_name in worker_names:
             if "$" in worker_name:
-                LOG.warning(
-                    f"Worker '{worker_name}' is unexpanded. Target provenance spec instead?"
-                )
+                LOG.warning(f"Worker '{worker_name}' is unexpanded. Target provenance spec instead?")
     router.stop_workers(args.task_server, worker_names, args.queues, args.workers)
 
 
@@ -381,8 +363,7 @@ def setup_argparse() -> None:
         dest="level",
         type=str,
         default=DEFAULT_LOG_LEVEL,
-        help="Set the log level. Options: DEBUG, INFO, WARNING, ERROR. "
-        "[Default: %(default)s]",
+        help="Set the log level. Options: DEBUG, INFO, WARNING, ERROR. " "[Default: %(default)s]",
     )
 
     # merlin run
@@ -392,9 +373,7 @@ def setup_argparse() -> None:
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     run.set_defaults(func=process_run)
-    run.add_argument(
-        "specification", type=str, help="Path to a Merlin or Maestro YAML file"
-    )
+    run.add_argument("specification", type=str, help="Path to a Merlin or Maestro YAML file")
     run.add_argument(
         "--local",
         action="store_const",
@@ -461,9 +440,7 @@ def setup_argparse() -> None:
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     restart.set_defaults(func=process_restart)
-    restart.add_argument(
-        "restart_dir", type=str, help="Path to an existing Merlin workspace directory"
-    )
+    restart.add_argument("restart_dir", type=str, help="Path to an existing Merlin workspace directory")
     restart.add_argument(
         "--local",
         action="store_const",
@@ -482,9 +459,7 @@ def setup_argparse() -> None:
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     purge.set_defaults(func=purge_tasks)
-    purge.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
+    purge.add_argument("specification", type=str, help="Path to a Merlin YAML spec file")
     purge.add_argument(
         "-f",
         "--force",
@@ -560,8 +535,7 @@ def setup_argparse() -> None:
         action="store",
         type=str,
         default=None,
-        help="Specify a path to write the workflow to. Defaults to current "
-        "working directory",
+        help="Specify a path to write the workflow to. Defaults to current " "working directory",
     )
     example.set_defaults(func=process_example)
 
@@ -587,9 +561,7 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     run_workers.set_defaults(func=launch_workers)
-    run_workers.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
+    run_workers.add_argument("specification", type=str, help="Path to a Merlin YAML spec file")
     run_workers.add_argument(
         "--worker-args",
         type=str,
@@ -624,9 +596,7 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
     )
 
     # merlin query-workers
-    query: ArgumentParser = subparsers.add_parser(
-        "query-workers", help="List connected task server workers."
-    )
+    query: ArgumentParser = subparsers.add_parser("query-workers", help="List connected task server workers.")
     query.set_defaults(func=query_workers)
     query.add_argument(
         "--task_server",
@@ -637,9 +607,7 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
     )
 
     # merlin stop-workers
-    stop: ArgumentParser = subparsers.add_parser(
-        "stop-workers", help="Attempt to stop all task server workers."
-    )
+    stop: ArgumentParser = subparsers.add_parser("stop-workers", help="Attempt to stop all task server workers.")
     stop.set_defaults(func=stop_workers)
     stop.add_argument(
         "--spec",
@@ -654,9 +622,7 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
         help="Task server type from which to stop workers.\
                             Default: %(default)s",
     )
-    stop.add_argument(
-        "--queues", type=str, default=None, nargs="+", help="specific queues to stop"
-    )
+    stop.add_argument("--queues", type=str, default=None, nargs="+", help="specific queues to stop")
     stop.add_argument(
         "--workers",
         type=str,
@@ -670,9 +636,7 @@ def generate_worker_touching_parsers(subparsers: ArgumentParser) -> None:
         help="Check for active workers on an allocation.",
         formatter_class=RawTextHelpFormatter,
     )
-    monitor.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
+    monitor.add_argument("specification", type=str, help="Path to a Merlin YAML spec file")
     monitor.add_argument(
         "--steps",
         nargs="+",
@@ -721,9 +685,7 @@ def generate_diagnostic_parsers(subparsers: ArgumentParser) -> None:
                               number of connected workers) for a workflow spec.",
     )
     status.set_defaults(func=query_status)
-    status.add_argument(
-        "specification", type=str, help="Path to a Merlin YAML spec file"
-    )
+    status.add_argument("specification", type=str, help="Path to a Merlin YAML spec file")
     status.add_argument(
         "--steps",
         nargs="+",
@@ -749,9 +711,7 @@ def generate_diagnostic_parsers(subparsers: ArgumentParser) -> None:
         help="Specify desired Merlin variable values to override those found in the specification. Space-delimited. "
         "Example: '--vars LEARN=path/to/new_learn.py EPOCHS=3'",
     )
-    status.add_argument(
-        "--csv", type=str, help="csv file to dump status report to", default=None
-    )
+    status.add_argument("--csv", type=str, help="csv file to dump status report to", default=None)
 
     # merlin info
     info: ArgumentParser = subparsers.add_parser(

--- a/merlin/merlin_templates.py
+++ b/merlin/merlin_templates.py
@@ -44,9 +44,7 @@ DEFAULT_LOG_LEVEL = "ERROR"
 
 
 def process_templates(args):
-    LOG.error(
-        "The command `merlin-templates` has been deprecated in favor of `merlin example`."
-    )
+    LOG.error("The command `merlin-templates` has been deprecated in favor of `merlin example`.")
 
 
 def setup_argparse():

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -257,13 +257,9 @@ def check_merlin_status(args, spec):
         while count < max_count:
             # This list will include strings comprised of the worker name with the hostname e.g. worker_name@host.
             worker_status = get_workers(args.task_server)
-            LOG.info(
-                f"Monitor: checking for workers, running workers = {worker_status} ..."
-            )
+            LOG.info(f"Monitor: checking for workers, running workers = {worker_status} ...")
 
-            check = any(
-                any(iwn in iws for iws in worker_status) for iwn in worker_names
-            )
+            check = any(any(iwn in iws for iws in worker_status) for iwn in worker_names)
             if check:
                 break
 

--- a/merlin/spec/expansion.py
+++ b/merlin/spec/expansion.py
@@ -81,11 +81,7 @@ def expand_line(line, var_dict, env_vars=False):
     Expand one line of text by substituting user variables,
     optionally environment variables, as well as variables in 'var_dict'.
     """
-    if (
-        (not contains_token(line))
-        and (not contains_shell_ref(line))
-        and ("~" not in line)
-    ):
+    if (not contains_token(line)) and (not contains_shell_ref(line)) and ("~" not in line):
         return line
     for key, val in var_dict.items():
         if key in line:
@@ -159,25 +155,19 @@ def determine_user_variables(*user_var_dicts):
     determined_results = {}
     for key, val in all_var_dicts.items():
         if key in RESERVED:
-            raise ValueError(
-                f"Cannot reassign value of reserved word '{key}'! Reserved words are: {RESERVED}."
-            )
+            raise ValueError(f"Cannot reassign value of reserved word '{key}'! Reserved words are: {RESERVED}.")
         new_val = str(val)
         if contains_token(new_val):
             for determined_key in determined_results.keys():
                 var_determined_key = var_ref(determined_key)
                 if var_determined_key in new_val:
-                    new_val = new_val.replace(
-                        var_determined_key, determined_results[determined_key]
-                    )
+                    new_val = new_val.replace(var_determined_key, determined_results[determined_key])
         new_val = expandvars(expanduser(new_val))
         determined_results[key.upper()] = new_val
     return determined_results
 
 
-def parameter_substitutions_for_sample(
-    sample, labels, sample_id, relative_path_to_sample
-):
+def parameter_substitutions_for_sample(sample, labels, sample_id, relative_path_to_sample):
     """
     :param sample : The sample to do substitution for.
     :param labels : The column labels of the sample.

--- a/merlin/spec/override.py
+++ b/merlin/spec/override.py
@@ -14,9 +14,7 @@ def error_override_vars(override_vars, spec_filepath):
     original_text = open(spec_filepath, "r").read()
     for variable in override_vars.keys():
         if variable not in original_text:
-            raise ValueError(
-                f"Command line override variable '{variable}' not found in spec file '{spec_filepath}'."
-            )
+            raise ValueError(f"Command line override variable '{variable}' not found in spec file '{spec_filepath}'.")
 
 
 def replace_override_vars(env, override_vars):

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -144,9 +144,7 @@ class MerlinSpec(YAMLSpecification):
         MerlinSpec.fill_missing_defaults(self.environment, defaults.ENV["env"])
 
         # fill in missing global parameter section defaults
-        MerlinSpec.fill_missing_defaults(
-            self.globals, defaults.PARAMETER["global.parameters"]
-        )
+        MerlinSpec.fill_missing_defaults(self.globals, defaults.PARAMETER["global.parameters"])
 
         # fill in missing step section defaults within 'run'
         defaults.STUDY_STEP_RUN["shell"] = self.batch["shell"]
@@ -176,9 +174,7 @@ class MerlinSpec(YAMLSpecification):
             if not isinstance(defaults, dict):
                 return
             for key, val in defaults.items():
-                if (key not in result) or (
-                    (result[key] is None) and (defaults[key] is not None)
-                ):
+                if (key not in result) or ((result[key] is None) and (defaults[key] is not None)):
                     result[key] = val
                 else:
                     recurse(result[key], val)
@@ -202,31 +198,21 @@ class MerlinSpec(YAMLSpecification):
         # check steps
         for step in self.study:
             MerlinSpec.check_section(step["name"], step, all_keys.STUDY_STEP)
-            MerlinSpec.check_section(
-                step["name"] + ".run", step["run"], all_keys.STUDY_STEP_RUN
-            )
+            MerlinSpec.check_section(step["name"] + ".run", step["run"], all_keys.STUDY_STEP_RUN)
 
         # check merlin
         MerlinSpec.check_section("merlin", self.merlin, all_keys.MERLIN)
-        MerlinSpec.check_section(
-            "merlin.resources", self.merlin["resources"], all_keys.MERLIN_RESOURCES
-        )
+        MerlinSpec.check_section("merlin.resources", self.merlin["resources"], all_keys.MERLIN_RESOURCES)
         for worker, contents in self.merlin["resources"]["workers"].items():
-            MerlinSpec.check_section(
-                "merlin.resources.workers " + worker, contents, all_keys.WORKER
-            )
+            MerlinSpec.check_section("merlin.resources.workers " + worker, contents, all_keys.WORKER)
         if self.merlin["samples"]:
-            MerlinSpec.check_section(
-                "merlin.samples", self.merlin["samples"], all_keys.SAMPLES
-            )
+            MerlinSpec.check_section("merlin.samples", self.merlin["samples"], all_keys.SAMPLES)
 
     @staticmethod
     def check_section(section_name, section, all_keys):
         diff = set(section.keys()).difference(all_keys)
         for extra in diff:
-            LOG.warn(
-                f"Unrecognized key '{extra}' found in spec section '{section_name}'."
-            )
+            LOG.warn(f"Unrecognized key '{extra}' found in spec section '{section_name}'.")
 
     def dump(self):
         """
@@ -287,16 +273,9 @@ class MerlinSpec(YAMLSpecification):
                 key_stack = deepcopy(key_stack)
                 key_stack.append("elem")
                 if use_hyphens:
-                    string += (
-                        (lvl + 1) * tab
-                        + "- "
-                        + str(self._dict_to_yaml(elem, "", key_stack, tab))
-                        + "\n"
-                    )
+                    string += (lvl + 1) * tab + "- " + str(self._dict_to_yaml(elem, "", key_stack, tab)) + "\n"
                 else:
-                    string += str(
-                        self._dict_to_yaml(elem, "", key_stack, tab, newline=(i != 0))
-                    )
+                    string += str(self._dict_to_yaml(elem, "", key_stack, tab, newline=(i != 0)))
                     if n > 1 and i != len(obj) - 1:
                         string += ", "
                 key_stack.pop()
@@ -317,12 +296,7 @@ class MerlinSpec(YAMLSpecification):
                     string += list_offset + (tab * lvl)
                 else:
                     string += tab * (lvl + 1)
-                string += (
-                    str(k)
-                    + ": "
-                    + str(self._dict_to_yaml(v, "", key_stack, tab))
-                    + "\n"
-                )
+                string += str(k) + ": " + str(self._dict_to_yaml(v, "", key_stack, tab)) + "\n"
                 key_stack.pop()
                 i += 1
         return string
@@ -357,9 +331,7 @@ class MerlinSpec(YAMLSpecification):
                     task_queues = [queues[steps]]
             except KeyError:
                 nl = "\n"
-                LOG.error(
-                    f"Invalid steps '{steps}'! Try one of these (or 'all'):\n{nl.join(queues.keys())}"
-                )
+                LOG.error(f"Invalid steps '{steps}'! Try one of these (or 'all'):\n{nl.join(queues.keys())}")
                 raise
         return sorted(set(task_queues))
 

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -149,9 +149,7 @@ def batch_worker_launch(
     if nodes is None or nodes == "all":
         nodes = get_node_count(default=1)
     elif not isinstance(nodes, int):
-        raise TypeError(
-            "Nodes was passed into batch_worker_launch with an invalid type (likely a string other than 'all')."
-        )
+        raise TypeError("Nodes was passed into batch_worker_launch with an invalid type (likely a string other than 'all').")
 
     shell: str = get_yaml_var(batch, "shell", "bash")
 
@@ -173,9 +171,7 @@ def batch_worker_launch(
     if btype == "flux":
         flux_path: str = get_yaml_var(batch, "flux_path", "")
         flux_opts: Union[str, Dict] = get_yaml_var(batch, "flux_start_opts", "")
-        flux_exec_workers: Union[str, Dict, bool] = get_yaml_var(
-            batch, "flux_exec_workers", True
-        )
+        flux_exec_workers: Union[str, Dict, bool] = get_yaml_var(batch, "flux_exec_workers", True)
 
         flux_exec: str = ""
         if flux_exec_workers:
@@ -194,9 +190,7 @@ def batch_worker_launch(
     return worker_cmd
 
 
-def construct_worker_launch_command(
-    batch: Optional[Dict], btype: str, nodes: int
-) -> str:
+def construct_worker_launch_command(batch: Optional[Dict], btype: str, nodes: int) -> str:
     """
     If no 'worker_launch' is found in the batch yaml, this method constructs the needed launch command.
 

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -39,13 +39,7 @@ import time
 from contextlib import suppress
 
 from merlin.study.batch import batch_check_parallel, batch_worker_launch
-from merlin.utils import (
-    check_machines,
-    get_procs,
-    get_yaml_var,
-    is_running,
-    regex_list_filter,
-)
+from merlin.utils import check_machines, get_procs, get_yaml_var, is_running, regex_list_filter
 
 
 LOG = logging.getLogger(__name__)
@@ -248,15 +242,11 @@ def start_celery_workers(spec, steps, celery_args, just_return_command):
             worker_args += " --logfile %p.%i"
 
         # Get the celery command
-        celery_com = launch_celery_workers(
-            spec, steps=wsteps, worker_args=worker_args, just_return_command=True
-        )
+        celery_com = launch_celery_workers(spec, steps=wsteps, worker_args=worker_args, just_return_command=True)
 
         celery_cmd = os.path.expandvars(celery_com)
 
-        worker_cmd = batch_worker_launch(
-            spec, celery_cmd, nodes=worker_nodes, batch=worker_batch
-        )
+        worker_cmd = batch_worker_launch(spec, celery_cmd, nodes=worker_nodes, batch=worker_batch)
 
         worker_cmd = os.path.expandvars(worker_cmd)
 
@@ -324,13 +314,10 @@ def examine_and_log_machines(worker_val, yenv) -> bool:
             output_path = get_yaml_var(yenv, "OUTPUT_PATH", None)
             if output_path and not os.path.exists(output_path):
                 hostname = socket.gethostname()
-                LOG.error(
-                    f"The output path, {output_path}, is not accessible on this host, {hostname}"
-                )
+                LOG.error(f"The output path, {output_path}, is not accessible on this host, {hostname}")
         else:
             LOG.warning(
-                "The env:variables section does not have an OUTPUT_PATH"
-                "specified, multi-machine checks cannot be performed."
+                "The env:variables section does not have an OUTPUT_PATH" "specified, multi-machine checks cannot be performed."
             )
         return False
 
@@ -340,19 +327,11 @@ def verify_args(spec, worker_args, worker_name, overlap):
     parallel = batch_check_parallel(spec)
     if parallel:
         if "--concurrency" not in worker_args:
-            LOG.warning(
-                "The worker arg --concurrency [1-4] is recommended "
-                "when running parallel tasks"
-            )
+            LOG.warning("The worker arg --concurrency [1-4] is recommended " "when running parallel tasks")
         if "--prefetch-multiplier" not in worker_args:
-            LOG.warning(
-                "The worker arg --prefetch-multiplier 1 is "
-                "recommended when running parallel tasks"
-            )
+            LOG.warning("The worker arg --prefetch-multiplier 1 is " "recommended when running parallel tasks")
         if "fair" not in worker_args:
-            LOG.warning(
-                "The worker arg -O fair is recommended when running parallel tasks"
-            )
+            LOG.warning("The worker arg -O fair is recommended when running parallel tasks")
 
     if "-n" not in worker_args:
         nhash = ""
@@ -423,9 +402,7 @@ def stop_celery_workers(queues=None, spec_worker_names=None, worker_regex=None):
     """
     from merlin.celery import app
 
-    LOG.debug(
-        f"Sending stop to queues: {queues}, worker_regex: {worker_regex}, spec_worker_names: {spec_worker_names}"
-    )
+    LOG.debug(f"Sending stop to queues: {queues}, worker_regex: {worker_regex}, spec_worker_names: {spec_worker_names}")
     active_queues, _ = get_queues(app)
 
     # If not specified, get all the queues
@@ -447,20 +424,14 @@ def stop_celery_workers(queues=None, spec_worker_names=None, worker_regex=None):
 
     print(f"all_workers: {all_workers}")
     print(f"spec_worker_names: {spec_worker_names}")
-    if (
-        spec_worker_names is None or len(spec_worker_names) == 0
-    ) and worker_regex is None:
+    if (spec_worker_names is None or len(spec_worker_names) == 0) and worker_regex is None:
         workers_to_stop = list(all_workers)
     else:
         workers_to_stop = []
         if (spec_worker_names is not None) and len(spec_worker_names) > 0:
             for worker_name in spec_worker_names:
-                print(
-                    f"Result of regex_list_filter: {regex_list_filter(worker_name, all_workers)}"
-                )
-                workers_to_stop += regex_list_filter(
-                    worker_name, all_workers, match=False
-                )
+                print(f"Result of regex_list_filter: {regex_list_filter(worker_name, all_workers)}")
+                workers_to_stop += regex_list_filter(worker_name, all_workers, match=False)
         if worker_regex is not None:
             workers_to_stop += regex_list_filter(worker_regex, workers_to_stop)
 

--- a/merlin/study/dag.py
+++ b/merlin/study/dag.py
@@ -169,9 +169,7 @@ class DAG:
         """
         step1 = self.step(task1)
         step2 = self.step(task2)
-        return step1.needs_merlin_expansion(
-            self.labels
-        ) == step2.needs_merlin_expansion(self.labels)
+        return step1.needs_merlin_expansion(self.labels) == step2.needs_merlin_expansion(self.labels)
 
     def find_independent_chains(self, list_of_groups_of_chains):
         """
@@ -206,16 +204,11 @@ class DAG:
 
                             if self.compatible_merlin_expansion(child, task_name):
 
-                                self.find_chain(child, list_of_groups_of_chains).remove(
-                                    child
-                                )
+                                self.find_chain(child, list_of_groups_of_chains).remove(child)
 
                                 chain.append(child)
 
-        new_list = [
-            [chain for chain in group if len(chain) > 0]
-            for group in list_of_groups_of_chains
-        ]
+        new_list = [[chain for chain in group if len(chain) > 0] for group in list_of_groups_of_chains]
         new_list_2 = [group for group in new_list if len(group) > 0]
 
         return new_list_2

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -357,9 +357,7 @@ class MerlinScriptAdapter(LocalScriptAdapter):
         # Using super prevents recursion.
         self.batch_adapter = super(MerlinScriptAdapter, self)
         if self.batch_type != "merlin-local":
-            self.batch_adapter = MerlinScriptAdapterFactory.get_adapter(
-                self.batch_type
-            )(**kwargs)
+            self.batch_adapter = MerlinScriptAdapterFactory.get_adapter(self.batch_type)(**kwargs)
 
     def write_script(self, *args, **kwargs):
         """
@@ -404,9 +402,7 @@ class MerlinScriptAdapter(LocalScriptAdapter):
         elif retcode == ReturnCode.STOP_WORKERS:
             LOG.debug("Execution returned status STOP_WORKERS")
         else:
-            LOG.warning(
-                f"Unrecognized Merlin Return code: {retcode}, returning SOFT_FAIL"
-            )
+            LOG.warning(f"Unrecognized Merlin Return code: {retcode}, returning SOFT_FAIL")
             submission_record._info["retcode"] = retcode
             retcode = ReturnCode.SOFT_FAIL
 
@@ -417,9 +413,7 @@ class MerlinScriptAdapter(LocalScriptAdapter):
 
         return submission_record
 
-    def _execute_subprocess(
-        self, output_name, script_path, cwd, env=None, join_output=False
-    ):
+    def _execute_subprocess(self, output_name, script_path, cwd, env=None, join_output=False):
         """
         Execute the subprocess script locally.
         If cwd is specified, the submit method will operate outside of the path
@@ -437,9 +431,7 @@ class MerlinScriptAdapter(LocalScriptAdapter):
         """
         script_bn = os.path.basename(script_path)
         new_output_name = os.path.splitext(script_bn)[0]
-        LOG.debug(
-            f"script_path={script_path}, output_name={output_name}, new_output_name={new_output_name}"
-        )
+        LOG.debug(f"script_path={script_path}, output_name={output_name}, new_output_name={new_output_name}")
         p = start_process(script_path, shell=False, cwd=cwd, env=env)
         pid = p.pid
         output, err = p.communicate()

--- a/merlin/study/step.py
+++ b/merlin/study/step.py
@@ -56,16 +56,13 @@ class MerlinStepRecord(_StepRecord):
 
     def mark_submitted(self):
         """Mark the submission time of the record."""
-        LOG.debug(
-            "Marking %s as submitted (PENDING) -- previously %s", self.name, self.status
-        )
+        LOG.debug("Marking %s as submitted (PENDING) -- previously %s", self.name, self.status)
         self.status = State.PENDING
         if not self._submit_time:
             self._submit_time = datetime.now()
         else:
             LOG.debug(
-                "Merlin: Cannot set the submission time of '%s' because it has "
-                "already been set.",
+                "Merlin: Cannot set the submission time of '%s' because it has " "already been set.",
                 self.name,
             )
 
@@ -95,9 +92,7 @@ class Step:
         """
         return self.mstep.step.__dict__["run"]["restart"]
 
-    def clone_changing_workspace_and_cmd(
-        self, new_cmd=None, cmd_replacement_pairs=None, new_workspace=None
-    ):
+    def clone_changing_workspace_and_cmd(self, new_cmd=None, cmd_replacement_pairs=None, new_workspace=None):
         """
         Produces a deep copy of the current step, performing variable
         substitutions as we go
@@ -120,9 +115,7 @@ class Step:
 
                 restart_cmd = step_dict["run"]["restart"]
                 if restart_cmd:
-                    step_dict["run"]["restart"] = re.sub(
-                        re.escape(str1), str2, restart_cmd, flags=re.I
-                    )
+                    step_dict["run"]["restart"] = re.sub(re.escape(str1), str2, restart_cmd, flags=re.I)
 
         if new_workspace is None:
             new_workspace = self.get_workspace()

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -43,21 +43,11 @@ from maestrowf.utils import create_dictionary
 
 from merlin.common.abstracts.enums import ReturnCode
 from merlin.spec import defaults
-from merlin.spec.expansion import (
-    determine_user_variables,
-    expand_by_line,
-    expand_env_vars,
-    expand_line,
-)
+from merlin.spec.expansion import determine_user_variables, expand_by_line, expand_env_vars, expand_line
 from merlin.spec.override import error_override_vars, replace_override_vars
 from merlin.spec.specification import MerlinSpec
 from merlin.study.dag import DAG
-from merlin.utils import (
-    contains_shell_ref,
-    contains_token,
-    get_flux_cmd,
-    load_array_file,
-)
+from merlin.utils import contains_shell_ref, contains_token, get_flux_cmd, load_array_file
 
 
 LOG = logging.getLogger(__name__)
@@ -142,9 +132,7 @@ class MerlinStudy:
         if self.original_spec.merlin["samples"]:
             for label in self.original_spec.merlin["samples"]["column_labels"]:
                 if label in self.original_spec.globals:
-                    raise ValueError(
-                        f"column_label {label} cannot also be " "in global.parameters!"
-                    )
+                    raise ValueError(f"column_label {label} cannot also be " "in global.parameters!")
 
     @staticmethod
     def get_user_vars(spec):
@@ -169,16 +157,12 @@ class MerlinStudy:
         Useful for provenance.
         """
         # get specification including defaults and cli-overridden user variables
-        new_env = replace_override_vars(
-            self.original_spec.environment, self.override_vars
-        )
+        new_env = replace_override_vars(self.original_spec.environment, self.override_vars)
         new_spec = deepcopy(self.original_spec)
         new_spec.environment = new_env
 
         # expand user variables
-        new_spec_text = expand_by_line(
-            new_spec.dump(), MerlinStudy.get_user_vars(new_spec)
-        )
+        new_spec_text = expand_by_line(new_spec.dump(), MerlinStudy.get_user_vars(new_spec))
 
         # expand reserved words
         new_spec_text = expand_by_line(new_spec_text, self.special_vars)
@@ -288,9 +272,7 @@ class MerlinStudy:
         else:
             output_path = str(self.original_spec.output_path)
 
-            if (self.override_vars is not None) and (
-                "OUTPUT_PATH" in self.override_vars
-            ):
+            if (self.override_vars is not None) and ("OUTPUT_PATH" in self.override_vars):
                 output_path = str(self.override_vars["OUTPUT_PATH"])
 
             output_path = expand_line(output_path, self.user_vars, env_vars=True)
@@ -321,9 +303,7 @@ class MerlinStudy:
         """
         if self.restart_dir is not None:
             if not os.path.isdir(self.restart_dir):
-                raise ValueError(
-                    f"Restart directory '{self.restart_dir}' does not exist!"
-                )
+                raise ValueError(f"Restart directory '{self.restart_dir}' does not exist!")
             return os.path.abspath(self.restart_dir)
 
         workspace_name = f'{self.original_spec.name.replace(" ", "_")}_{self.timestamp}'
@@ -362,26 +342,20 @@ class MerlinStudy:
         expanded_filepath = os.path.join(self.info, expanded_name)
 
         # expand provenance spec filename
-        if contains_token(self.original_spec.name) or contains_shell_ref(
-            self.original_spec.name
-        ):
+        if contains_token(self.original_spec.name) or contains_shell_ref(self.original_spec.name):
             name = f"{result.description['name'].replace(' ', '_')}_{self.timestamp}"
             name = expand_line(name, {}, env_vars=True)
             if "/" in name:
-                raise ValueError(
-                    f"Expanded value '{name}' for field 'name' in section 'description' is not a valid filename."
-                )
+                raise ValueError(f"Expanded value '{name}' for field 'name' in section 'description' is not a valid filename.")
             expanded_workspace = os.path.join(self.output_path, name)
 
             if result.merlin["samples"]:
                 sample_file = result.merlin["samples"]["file"]
                 if sample_file.startswith(self.workspace):
-                    new_samples_file = sample_file.replace(
+                    new_samples_file = sample_file.replace(self.workspace, expanded_workspace)
+                    result.merlin["samples"]["generate"]["cmd"] = result.merlin["samples"]["generate"]["cmd"].replace(
                         self.workspace, expanded_workspace
                     )
-                    result.merlin["samples"]["generate"]["cmd"] = result.merlin[
-                        "samples"
-                    ]["generate"]["cmd"].replace(self.workspace, expanded_workspace)
                     result.merlin["samples"]["file"] = new_samples_file
 
             shutil.move(self.workspace, expanded_workspace)
@@ -390,9 +364,7 @@ class MerlinStudy:
             self.special_vars["MERLIN_INFO"] = self.info
 
             expanded_filepath = os.path.join(self.info, expanded_name)
-            new_spec_text = expand_by_line(
-                result.dump(), MerlinStudy.get_user_vars(result)
-            )
+            new_spec_text = expand_by_line(result.dump(), MerlinStudy.get_user_vars(result))
             result = MerlinSpec.load_spec_from_string(new_spec_text)
             result = expand_env_vars(result)
 
@@ -458,9 +430,7 @@ class MerlinStudy:
         """
         try:
             if not os.path.exists(self.samples_file):
-                sample_generate = self.expanded_spec.merlin["samples"]["generate"][
-                    "cmd"
-                ]
+                sample_generate = self.expanded_spec.merlin["samples"]["generate"]["cmd"]
                 LOG.info("Generating samples...")
                 sample_process = subprocess.Popen(
                     sample_generate,

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -79,11 +79,7 @@ def get_user_process_info(user=None, attrs=None):
     if user == "all_users":
         return [p.info for p in psutil.process_iter(attrs=attrs)]
     else:
-        return [
-            p.info
-            for p in psutil.process_iter(attrs=attrs)
-            if user in p.info["username"]
-        ]
+        return [p.info for p in psutil.process_iter(attrs=attrs) if user in p.info["username"]]
 
 
 def check_pid(pid, user=None):
@@ -154,9 +150,7 @@ def is_running(name, all_users=False):
         cmd[1] = "aux"
 
     try:
-        ps = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, encoding="utf8"
-        ).communicate()[0]
+        ps = subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding="utf8").communicate()[0]
     except TypeError:
         ps = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0]
 
@@ -380,9 +374,7 @@ def get_flux_version(flux_path, no_errors=False):
     ps = None
 
     try:
-        ps = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, encoding="utf8"
-        ).communicate()
+        ps = subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding="utf8").communicate()
     except FileNotFoundError as e:
         if not no_errors:
             LOG.error(f"The flux path {flux_path} canot be found")
@@ -472,9 +464,7 @@ def convert_to_timedelta(timestr: Union[str, int]) -> timedelta:
     timestr = str(timestr)
     nfields = len(timestr.split(":"))
     if nfields > 4:
-        raise ValueError(
-            f"Cannot convert {timestr} to a timedelta. Valid format: days:hours:minutes:seconds."
-        )
+        raise ValueError(f"Cannot convert {timestr} to a timedelta. Valid format: days:hours:minutes:seconds.")
     _, d, h, m, s = (":0" * 10 + timestr).rsplit(":", 4)
     tdelta = timedelta(days=int(d), hours=int(h), minutes=int(m), seconds=int(s))
     return tdelta
@@ -508,9 +498,7 @@ def repr_timedelta(td: timedelta, method: str = "HMS") -> str:
     elif method == "FSD":
         return _repr_timedelta_FSD(td)
     else:
-        raise ValueError(
-            "Invalid method for formatting timedelta! Valid choices: HMS, FSD"
-        )
+        raise ValueError("Invalid method for formatting timedelta! Valid choices: HMS, FSD")
 
 
 def convert_timestring(timestring: Union[str, int], format_method: str = "HMS") -> str:

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,7 @@ def _pip_requirement(req):
 def _reqs(*f):
     return [
         _pip_requirement(r)
-        for r in (
-            _strip_comments(line)
-            for line in open(os.path.join(os.getcwd(), "requirements", *f)).readlines()
-        )
+        for r in (_strip_comments(line) for line in open(os.path.join(os.getcwd(), "requirements", *f)).readlines())
         if r
     ]
 

--- a/tests/integration/conditions.py
+++ b/tests/integration/conditions.py
@@ -219,10 +219,7 @@ class ProvenanceYAMLFileHasRegex(HasRegex):
 
     @property
     def glob_string(self):
-        return (
-            f"{self.output_path}/{self.name}"
-            f"_[0-9]*-[0-9]*/merlin_info/{self.name}.{self.prov_type}.yaml"
-        )
+        return f"{self.output_path}/{self.name}" f"_[0-9]*-[0-9]*/merlin_info/{self.name}.{self.prov_type}.yaml"
 
     def is_within(self):
         """

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -175,9 +175,7 @@ def run_tests(args, tests):
     if failures == 0:
         print(f"Done. {n_to_run} tests passed in {round(total_time, 2)} s.")
         return 0
-    print(
-        f"Done. {failures} tests out of {n_to_run} failed after {round(total_time, 2)} s.\n"
-    )
+    print(f"Done. {failures} tests out of {n_to_run} failed after {round(total_time, 2)} s.\n")
     return 1
 
 
@@ -188,12 +186,8 @@ def setup_argparse():
         action="store_true",
         help="Flag for stopping all testing upon first failure",
     )
-    parser.add_argument(
-        "--verbose", action="store_true", help="Flag for more detailed output messages"
-    )
-    parser.add_argument(
-        "--local", action="store_true", default=None, help="Run only local tests"
-    )
+    parser.add_argument("--verbose", action="store_true", help="Flag for more detailed output messages")
+    parser.add_argument("--local", action="store_true", default=None, help="Run only local tests")
     parser.add_argument(
         "--ids",
         action="store",
@@ -201,8 +195,7 @@ def setup_argparse():
         type=int,
         nargs="+",
         default=None,
-        help="Provide space-delimited ids of tests you want to run."
-        "Example: '--ids 1 5 8 13'",
+        help="Provide space-delimited ids of tests you want to run." "Example: '--ids 1 5 8 13'",
     )
     return parser
 

--- a/tests/integration/test_definitions.py
+++ b/tests/integration/test_definitions.py
@@ -1,10 +1,4 @@
-from conditions import (
-    HasRegex,
-    HasReturnCode,
-    ProvenanceYAMLFileHasRegex,
-    StepFileExists,
-    StepFileHasRegex,
-)
+from conditions import HasRegex, HasReturnCode, ProvenanceYAMLFileHasRegex, StepFileExists, StepFileHasRegex
 
 from merlin.utils import get_flux_cmd
 
@@ -161,9 +155,7 @@ def define_tests():
         ),
         "dry launch slurm": (
             f"{run} {slurm} --dry --local --no-errors --vars N_SAMPLES=2 OUTPUT_PATH=./{OUTPUT_DIR}",
-            StepFileHasRegex(
-                "runs", "*/runs.slurm.sh", "slurm_test", OUTPUT_DIR, "srun "
-            ),
+            StepFileHasRegex("runs", "*/runs.slurm.sh", "slurm_test", OUTPUT_DIR, "srun "),
             "local",
         ),
         "dry launch flux": (
@@ -179,9 +171,7 @@ def define_tests():
         ),
         "dry launch lsf": (
             f"{run} {lsf} --dry --local --no-errors --vars N_SAMPLES=2 OUTPUT_PATH=./{OUTPUT_DIR}",
-            StepFileHasRegex(
-                "runs", "*/runs.slurm.sh", "lsf_par", OUTPUT_DIR, "jsrun "
-            ),
+            StepFileHasRegex("runs", "*/runs.slurm.sh", "lsf_par", OUTPUT_DIR, "jsrun "),
             "local",
         ),
         "dry launch slurm restart": (

--- a/tests/unit/common/test_sample_index.py
+++ b/tests/unit/common/test_sample_index.py
@@ -24,9 +24,7 @@ def clear(func):
 
 @clear
 def test_index_file_writing():
-    indx = create_hierarchy(
-        1000000000, 10000, [100000000, 10000000, 1000000], root=TEST_DIR
-    )
+    indx = create_hierarchy(1000000000, 10000, [100000000, 10000000, 1000000], root=TEST_DIR)
     indx.write_directories()
     indx.write_multiple_sample_index_files()
     indx2 = read_hierarchy(TEST_DIR)
@@ -34,9 +32,7 @@ def test_index_file_writing():
 
 
 def test_bundle_retrieval():
-    indx = create_hierarchy(
-        1000000000, 10000, [100000000, 10000000, 1000000], root=TEST_DIR
-    )
+    indx = create_hierarchy(1000000000, 10000, [100000000, 10000000, 1000000], root=TEST_DIR)
     expected = f"{TEST_DIR}/0/0/0/samples0-10000.ext"
     result = indx.get_path_to_sample(123)
     assert expected == result
@@ -97,9 +93,7 @@ def test_directory_writing():
     clear_test_tree()
 
     path = os.path.join(TEST_DIR)
-    indx = create_hierarchy(
-        1000000000, 10000, [100000000, 10000000, 1000000], root=path
-    )
+    indx = create_hierarchy(1000000000, 10000, [100000000, 10000000, 1000000], root=path)
     indx.write_directories()
 
 

--- a/tests/unit/spec/test_specification.py
+++ b/tests/unit/spec/test_specification.py
@@ -166,13 +166,7 @@ class TestSpecNoMerlin(unittest.TestCase):
     def test_default_merlin_block(self):
         self.assertEqual(self.spec.merlin["resources"]["task_server"], "celery")
         self.assertEqual(self.spec.merlin["resources"]["overlap"], False)
-        self.assertEqual(
-            self.spec.merlin["resources"]["workers"]["default_worker"]["steps"], ["all"]
-        )
-        self.assertEqual(
-            self.spec.merlin["resources"]["workers"]["default_worker"]["batch"], None
-        )
-        self.assertEqual(
-            self.spec.merlin["resources"]["workers"]["default_worker"]["nodes"], None
-        )
+        self.assertEqual(self.spec.merlin["resources"]["workers"]["default_worker"]["steps"], ["all"])
+        self.assertEqual(self.spec.merlin["resources"]["workers"]["default_worker"]["batch"], None)
+        self.assertEqual(self.spec.merlin["resources"]["workers"]["default_worker"]["nodes"], None)
         self.assertEqual(self.spec.merlin["samples"], None)

--- a/tests/unit/study/test_study.py
+++ b/tests/unit/study/test_study.py
@@ -254,43 +254,27 @@ class TestMerlinStudy(unittest.TestCase):
         object, the MerlinStudy should produce a new spec with all instances
         of $(OUTPUT_PATH), $(SPECROOT), and env labels and variables expanded.
         """
-        assert TestMerlinStudy.file_contains_string(
-            self.merlin_spec_filepath, "$(SPECROOT)"
-        )
-        assert TestMerlinStudy.file_contains_string(
-            self.merlin_spec_filepath, "$(OUTPUT_PATH)"
-        )
+        assert TestMerlinStudy.file_contains_string(self.merlin_spec_filepath, "$(SPECROOT)")
+        assert TestMerlinStudy.file_contains_string(self.merlin_spec_filepath, "$(OUTPUT_PATH)")
         assert TestMerlinStudy.file_contains_string(self.merlin_spec_filepath, "$PATH")
 
-        assert not TestMerlinStudy.file_contains_string(
-            self.study.expanded_spec.path, "$(SPECROOT)"
-        )
-        assert not TestMerlinStudy.file_contains_string(
-            self.study.expanded_spec.path, "$(OUTPUT_PATH)"
-        )
-        assert TestMerlinStudy.file_contains_string(
-            self.study.expanded_spec.path, "$PATH"
-        )
-        assert not TestMerlinStudy.file_contains_string(
-            self.study.expanded_spec.path, "PATH_VAR: $PATH"
-        )
+        assert not TestMerlinStudy.file_contains_string(self.study.expanded_spec.path, "$(SPECROOT)")
+        assert not TestMerlinStudy.file_contains_string(self.study.expanded_spec.path, "$(OUTPUT_PATH)")
+        assert TestMerlinStudy.file_contains_string(self.study.expanded_spec.path, "$PATH")
+        assert not TestMerlinStudy.file_contains_string(self.study.expanded_spec.path, "PATH_VAR: $PATH")
 
     def test_column_label_conflict(self):
         """
         If there is a common key between Maestro's global.parameters and
         Merlin's sample/column_labels, an error should be raised.
         """
-        merlin_spec_conflict: str = os.path.join(
-            self.tmpdir, "basic_ensemble_conflict.yaml"
-        )
+        merlin_spec_conflict: str = os.path.join(self.tmpdir, "basic_ensemble_conflict.yaml")
         with open(merlin_spec_conflict, "w+") as _file:
             _file.write(MERLIN_SPEC_CONFLICT)
         # for some reason flake8 doesn't believe variables instantiated inside the try/with context are assigned
         with pytest.raises(ValueError):
             study_conflict: MerlinStudy = MerlinStudy(merlin_spec_conflict)
-            assert (
-                not study_conflict
-            ), "study_conflict completed construction without raising a ValueError."
+            assert not study_conflict, "study_conflict completed construction without raising a ValueError."
 
     # TODO the pertinent attribute for study_no_env should be examined and asserted to be empty
     def test_no_env(self):
@@ -298,18 +282,12 @@ class TestMerlinStudy(unittest.TestCase):
         A MerlinStudy should be able to support a MerlinSpec that does not contain
         the optional `env` section.
         """
-        merlin_spec_no_env_filepath: str = os.path.join(
-            self.tmpdir, "basic_ensemble_no_env.yaml"
-        )
+        merlin_spec_no_env_filepath: str = os.path.join(self.tmpdir, "basic_ensemble_no_env.yaml")
         with open(merlin_spec_no_env_filepath, "w+") as _file:
             _file.write(MERLIN_SPEC_NO_ENV)
         try:
             study_no_env: MerlinStudy = MerlinStudy(merlin_spec_no_env_filepath)
-            bad_type_err: str = (
-                f"study_no_env failed construction, is type {type(study_no_env)}."
-            )
+            bad_type_err: str = f"study_no_env failed construction, is type {type(study_no_env)}."
             assert isinstance(study_no_env, MerlinStudy), bad_type_err
         except Exception as e:
-            assert (
-                False
-            ), f"Encountered unexpected exception, {e}, for viable MerlinSpec without optional 'env' section."
+            assert False, f"Encountered unexpected exception, {e}, for viable MerlinSpec without optional 'env' section."

--- a/tests/unit/utils/test_time_formats.py
+++ b/tests/unit/utils/test_time_formats.py
@@ -39,17 +39,11 @@ def test_convert_explicit(time_string: str, expected_result: str, method: str) -
     ],
 )
 @pytest.mark.parametrize("method", ["HMS", "FSD", None])
-def test_convert_timestring_same(
-    test_case: List[Union[str, int]], expected_bool: bool, method: Optional[str]
-) -> None:
+def test_convert_timestring_same(test_case: List[Union[str, int]], expected_bool: bool, method: Optional[str]) -> None:
     """Test that HMS formatted all the same"""
     err_msg: str = f"Failed on test case '{test_case}', expected {expected_bool}, not '{not expected_bool}'"
-    converted_times: List[str] = [
-        convert_timestring(time_strings) for time_strings in test_case
-    ]
-    all_equal: bool = all(
-        time_string == converted_times[0] for time_string in converted_times
-    )
+    converted_times: List[str] = [convert_timestring(time_strings) for time_strings in test_case]
+    all_equal: bool = all(time_string == converted_times[0] for time_string in converted_times)
     assert all_equal == expected_bool, err_msg
 
 
@@ -57,9 +51,5 @@ def test_invalid_time_format() -> None:
     """Test that if not provided an appropriate format (HMS, FSD), the appropriate error is thrown."""
     with pytest.raises(ValueError) as invalid_format:
         repr_timedelta(datetime.timedelta(1), "HMD")
-    examination_err_msg: str = (
-        "Did not raise correct ValueError for failed repr_timedelta()."
-    )
-    assert "Invalid method for formatting timedelta! Valid choices: HMS, FSD" in str(
-        invalid_format.value
-    ), examination_err_msg
+    examination_err_msg: str = "Did not raise correct ValueError for failed repr_timedelta()."
+    assert "Invalid method for formatting timedelta! Valid choices: HMS, FSD" in str(invalid_format.value), examination_err_msg


### PR DESCRIPTION
Currently we require Black and iSort, but their only enforcement is manual (a reviewer asking 'was this linted with black and isort?', and typically at the point of merging into main. This makes those two a regular part of linting and lints the codebase under the same constraints used for Flake8 and Pylint.