### PR TITLE
Release 1.8.1 (#330)

### DIFF
--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -38,7 +38,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=15 --statistics --max-line-length=88
+        flake8 . --count --max-complexity=15 --statistics --max-line-length=127
 
     - name: Run pytest over unit test suite
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1]
 
+### Fixed
+- merlin purge queue name conflict & shell quote escape
+- task priority support for amqp, amqps, rediss, redis+socket brokers
+- Flake8 compliance
 
 ## [1.8.0]
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -29,52 +29,126 @@
 ###############################################################################
 include config.mk
 
-.PHONY : all
-.PHONY : install-dev
 .PHONY : virtualenv
-.PHONY : install-workflow-deps
 .PHONY : install-merlin
-.PHONY : clean-output
-.PHONY : clean-docs
-.PHONY : clean-release
-.PHONY : clean-py
-.PHONY : clean
-.PHONY : release
+.PHONY : install-workflow-deps
+.PHONY : install-merlin-dev
 .PHONY : unit-tests
-.PHONY : cli-tests
+.PHONY : e2e-tests
 .PHONY : tests
 .PHONY : fix-style
 .PHONY : check-style
+.PHONY : check-push
 .PHONY : check-camel-case
 .PHONY : checks
 .PHONY : reqlist
-.PHONY : check-variables
+.PHONY : release
+.PHONY : clean-release
+.PHONY : clean-output
+.PHONY : clean-docs
+.PHONY : clean-py
+.PHONY : clean
+
+# this only works outside the venv - if run from inside a custom venv, or any target that depends on this,
+# you will break your venv.
+virtualenv:
+	$(PYTHON) -m venv $(VENV) --prompt $(PENV) --system-site-packages; \
+	$(PIP) install --upgrade pip; \
+	$(PIP) install -r requirements/release.txt; \
+
+# install merlin into the virtual environment
+install-merlin: virtualenv
+	$(PIP) install -e .; \
+	merlin config; \
 
 
-all: install-dev install-merlin install-workflow-deps
+# install the example workflow to enable integrated testing
+install-workflow-deps: virtualenv install-merlin
+	$(PIP) install -r $(WKFW)feature_demo/requirements.txt; \
 
 
 # install requirements
-install-dev: virtualenv
-	$(PIP) install -r requirements/dev.txt
+install-merlin-dev: virtualenv install-workflow-deps
+	$(PIP) install -r requirements/dev.txt; \
 
 
-check-variables:
-	- echo MAX_LINE_LENGTH $(MAX_LINE_LENGTH)
+# tests require a valid dev install of merlin
+unit-tests:
+	. $(VENV)/bin/activate; \
+	$(PYTHON) -m pytest $(UNIT); \
 
 
-# this only works outside the venv
-virtualenv:
-	$(PYTHON) -m venv $(VENV) --prompt $(PENV) --system-site-packages
-	$(PIP) install --upgrade pip
+# run CLI tests - these require an active install of merlin in a venv
+e2e-tests:
+	. $(VENV)/bin/activate; \
+	$(PYTHON) $(TEST)/integration/run_tests.py --local; \
 
 
-install-workflow-deps:
-	$(PIP) install -r $(WKFW)feature_demo/requirements.txt
+e2e-tests-diagnostic:
+	$(PYTHON) $(TEST)/integration/run_tests.py --local --verbose
 
 
-install-merlin:
-	$(PIP) install -e .
+# run unit and CLI tests
+tests: unit-tests e2e-tests
+
+
+# run code style checks
+check-style:
+	. $(VENV)/bin/activate
+	-$(PYTHON) -m flake8 --count --select=E9,F63,F7,F82 --show-source --statistics
+	-$(PYTHON) -m flake8 . --count --max-complexity=15 --statistics --max-line-length=127
+	-black --check --target-version py36 $(MRLN)
+
+
+check-push: tests check-style
+
+# finds all strings in project that begin with a lowercase letter,
+# contain only letters and numbers, and contain at least one lowercase
+# letter and at least one uppercase letter.
+check-camel-case: clean-py
+	grep -rnw --exclude=lbann_pb2.py $(MRLN) -e "[a-z]\([A-Z0-9]*[a-z][a-z0-9]*[A-Z]\|[a-z0-9]*[A-Z][A-Z0-9]*[a-z]\)[A-Za-z0-9]*"
+
+
+# run all checks
+checks: check-style check-camel-case
+
+
+# automatically make python files pep 8-compliant
+fix-style:
+	pip3 install -r requirements/dev.txt -U
+	isort -rc $(MRLN)
+	isort -rc $(TEST)
+	isort *.py
+	black --target-version py36 $(MRLN)
+	black --target-version py36 $(TEST)
+	black --target-version py36 *.py
+
+
+# Increment the Merlin version. USE ONLY ON DEVELOP BEFORE MERGING TO MASTER.
+# Use like this: make VER=?.?.? version
+version:
+# do merlin/__init__.py
+	sed -i 's/__version__ = "$(VSTRING)"/__version__ = "$(VER)"/g' merlin/__init__.py
+# do CHANGELOG.md
+	sed -i 's/## \[Unreleased\]/## [$(VER)]/g' CHANGELOG.md
+# do all file headers (works on linux)
+	find merlin/ -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
+	find *.py -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
+	find tests/ -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
+	find Makefile -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
+
+# Make a list of all dependencies/requirements
+reqlist:
+	johnnydep merlin --output-format pinned
+
+
+release:
+	$(PYTHON) setup.py sdist bdist_wheel
+
+
+clean-release:
+	rm -rf dist
+	rm -rf build
 
 
 # remove python bytecode files
@@ -95,73 +169,5 @@ clean-docs:
 	rm -rf $(DOCS)/build
 
 
-clean-release:
-	rm -rf dist
-	rm -rf build
-
-
 # remove unwanted files
 clean: clean-py clean-docs clean-release
-
-
-release:
-	$(PYTHON) setup.py sdist bdist_wheel
-
-
-unit-tests:
-	-$(PYTHON) -m pytest $(UNIT)
-
-
-# run CLI tests
-cli-tests:
-	-$(PYTHON) $(TEST)/integration/run_tests.py --local
-
-
-# run unit and CLI tests
-tests: unit-tests cli-tests
-
-
-# automatically make python files pep 8-compliant
-fix-style:
-	pip3 install -r requirements/dev.txt -U
-	isort -rc $(MRLN)
-	isort -rc $(TEST)
-	isort *.py
-	black --target-version py36 $(MRLN)
-	black --target-version py36 $(TEST)
-	black --target-version py36 *.py
-
-
-# run code style checks
-check-style:
-	-$(PYTHON) -m flake8 --max-complexity $(MAX_COMPLEXITY) --max-line-length $(MAX_LINE_LENGTH) --exclude ascii_art.py $(MRLN)
-	-black --check --target-version py36 $(MRLN)
-
-
-# finds all strings in project that begin with a lowercase letter,
-# contain only letters and numbers, and contain at least one lowercase
-# letter and at least one uppercase letter.
-check-camel-case: clean-py
-	grep -rnw --exclude=lbann_pb2.py $(MRLN) -e "[a-z]\([A-Z0-9]*[a-z][a-z0-9]*[A-Z]\|[a-z0-9]*[A-Z][A-Z0-9]*[a-z]\)[A-Za-z0-9]*"
-
-
-# run all checks
-checks: check-style check-camel-case
-
-
-# Increment the Merlin version. USE ONLY ON DEVELOP BEFORE MERGING TO MASTER.
-# Use like this: make VER=?.?.? verison
-version:
-	# do merlin/__init__.py
-	sed -i 's/__version__ = "$(VSTRING)"/__version__ = "$(VER)"/g' merlin/__init__.py
-	# do CHANGELOG.md
-	sed -i 's/## \[Unreleased\]/## [$(VER)]/g' CHANGELOG.md
-	# do all file headers (works on linux)
-	find merlin/ -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
-	find *.py -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
-	find tests/ -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
-	find Makefile -type f -print0 | xargs -0 sed -i 's/Version: $(VSTRING)/Version: $(VER)/g'
-
-# Make a list of all dependencies/requirements
-reqlist:
-	johnnydep merlin --output-format pinned

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 PYTHON?=python3
 PYV=$(shell $(PYTHON) -c "import sys;t='{v[0]}_{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")
 PYVD=$(shell $(PYTHON) -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")
-VENV?=venv_merlin_py$(PYV)
+VENV?=venv_merlin_py_$(PYV)
 PIP?=$(VENV)/bin/pip
 MRLN=merlin
 TEST=tests

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,10 +43,10 @@ release = MERLIN_VERSION
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-#extensions = [
+# extensions = [
 #    'sphinx.ext.autodoc',
 #    'sphinx.ext.intersphinx',
-#]
+# ]
 extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
@@ -104,8 +104,8 @@ html_static_path = ['_static']
 html_context = {
     'css_files': [
         '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+    ],
+}
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -182,6 +182,7 @@ primary_domain = 'py'
 highlight_language = 'bash'
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+
 
 def setup(app):
     app.add_stylesheet('custom.css')

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -38,7 +38,7 @@ import os
 import sys
 
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 VERSION = __version__
 PATH_TO_PROJ = os.path.join(os.path.dirname(__file__), "")
 

--- a/merlin/ascii_art.py
+++ b/merlin/ascii_art.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -27,6 +27,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 ###############################################################################
+
+# pylint: skip-file
 
 """
 Holds ascii art strings.

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/__init__.py
+++ b/merlin/common/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/__init__.py
+++ b/merlin/common/abstracts/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/enums/__init__.py
+++ b/merlin/common/abstracts/enums/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/openfilelist.py
+++ b/merlin/common/openfilelist.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -81,6 +81,7 @@ access among all of them.
      print a.dtype      # dtype of array
 
 """
+from typing import List, Tuple
 
 import numpy as np
 
@@ -280,16 +281,25 @@ class OpenNPY:
 
 
 class OpenNPYList:
-    def __init__(self, l):
-        self.filenames = l
-        self.files = [OpenNPY(_) for _ in self.filenames]
+    def __init__(self, filename_strs: List[str]):
+        self.filenames: List[str] = filename_strs
+        self.files: List[OpenNPY] = [OpenNPY(file_str) for file_str in self.filenames]
+        i: OpenNPY
         for i in self.files:
             i.load_header()
-        self.shapes = [_.hdr["shape"] for _ in self.files]
-        for i in self.shapes[1:]:
+        self.shapes: List[Tuple[int]] = [
+            openNPY_obj.hdr["shape"] for openNPY_obj in self.files
+        ]
+        k: Tuple[int]
+        for k in self.shapes[1:]:
             # Match subsequent axes shapes.
-            assert i[1:] == self.shapes[0][1:]
-        self.tells = np.cumsum([_[0] for _ in self.shapes])  # Tell locations.
+            if k[1:] != self.shapes[0][1:]:
+                raise AttributeError(
+                    f"Mismatch in subsequent axes shapes: {k[1:]} != {self.shapes[0][1:]}"
+                )
+        self.tells: np.ndarray = np.cumsum(
+            [arr_shape[0] for arr_shape in self.shapes]
+        )  # Tell locations.
         self.tells = np.hstack(([0], self.tells))
 
     def close(self):

--- a/merlin/common/sample_index.py
+++ b/merlin/common/sample_index.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/__init__.py
+++ b/merlin/common/security/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt.py
+++ b/merlin/common/security/encrypt.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt_backend_traffic.py
+++ b/merlin/common/security/encrypt_backend_traffic.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -33,6 +33,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
+from typing import Any, Dict, Optional
 
 from celery import chain, chord, group, shared_task, signature
 from celery.exceptions import MaxRetriesExceededError, OperationalError, TimeoutError
@@ -70,13 +71,13 @@ LOG = logging.getLogger(__name__)
 STOP_COUNTDOWN = 60
 
 
-@shared_task(
+@shared_task(  # noqa: C901
     bind=True,
     autoretry_for=retry_exceptions,
     retry_backoff=True,
     priority=get_priority(Priority.high),
 )
-def merlin_step(self, *args, **kwargs):
+def merlin_step(self, *args: Any, **kwargs: Any) -> Optional[ReturnCode]:  # noqa: C901
     """
     Executes a Merlin Step
     :param args: The arguments, one of which should be an instance of Step
@@ -88,25 +89,27 @@ def merlin_step(self, *args, **kwargs):
      "next_in_chain": <Step object> } # merlin_step will be added to the current chord
                                       # with next_in_chain as an argument
     """
-    step = None
+    step: Optional[Step] = None
     LOG.debug(f"args is {len(args)} long")
 
-    for a in args:
-        if isinstance(a, Step):
-            step = a
+    arg: Any
+    for arg in args:
+        if isinstance(arg, Step):
+            step = arg
         else:
-            LOG.debug(f"discard argument {a}")
+            LOG.debug(f"discard argument {arg}, not of type Step.")
 
-    config = kwargs.pop("adapter_config", {"type": "local"})
-    next_in_chain = kwargs.pop("next_in_chain", None)
+    config: Dict[str, str] = kwargs.pop("adapter_config", {"type": "local"})
+    next_in_chain: Optional[Step] = kwargs.pop("next_in_chain", None)
 
     if step:
         self.max_retries = step.max_retries
-        step_name = step.name()
-        step_dir = step.get_workspace()
+        step_name: str = step.name()
+        step_dir: str = step.get_workspace()
         LOG.debug(f"merlin_step: step_name '{step_name}' step_dir '{step_dir}'")
-        finished_filename = os.path.join(step_dir, "MERLIN_FINISHED")
+        finished_filename: str = os.path.join(step_dir, "MERLIN_FINISHED")
         # if we've already finished this task, skip it
+        result: ReturnCode
         if os.path.exists(finished_filename):
             LOG.info(f"Skipping step '{step_name}' in '{step_dir}'.")
             result = ReturnCode.OK
@@ -299,12 +302,12 @@ def add_merlin_expanded_chain_to_chord(
                 new_chain.append(new_step)
 
             all_chains.append(new_chain)
-        LOG.debug(f"adding chain to chord")
+        LOG.debug("adding chain to chord")
         add_chains_to_chord(self, all_chains)
-        LOG.debug(f"chain added to chord")
+        LOG.debug("chain added to chord")
     else:
         # recurse down the sample_index hierarchy
-        LOG.debug(f"recursing down sample_index hierarchy")
+        LOG.debug("recursing down sample_index hierarchy")
         for next_index in sample_index.children.values():
             next_index.name = os.path.join(sample_index.name, next_index.name)
             LOG.debug("generating next step")
@@ -486,7 +489,7 @@ def expand_tasks_with_samples(
     if needs_expansion:
         # prepare_chain_workspace(sample_index, steps)
         sample_index.name = ""
-        LOG.debug(f"queuing merlin expansion tasks")
+        LOG.debug("queuing merlin expansion tasks")
         found_tasks = False
         conditions = [
             lambda c: c.is_great_grandparent_of_leaf,
@@ -527,9 +530,9 @@ def expand_tasks_with_samples(
                     )
                     found_tasks = True
     else:
-        LOG.debug(f"queuing simple chain task")
+        LOG.debug("queuing simple chain task")
         add_simple_chain_to_chord(self, task_type, steps, adapter_config)
-        LOG.debug(f"simple chain task queued")
+        LOG.debug("simple chain task queued")
 
 
 @shared_task(
@@ -554,7 +557,7 @@ def shutdown_workers(self, shutdown_queues):
     if shutdown_queues is not None:
         LOG.warning(f"Shutting down workers in queues {shutdown_queues}!")
     else:
-        LOG.warning(f"Shutting down workers in all queues!")
+        LOG.warning("Shutting down workers in all queues!")
     return stop_workers("celery", None, shutdown_queues, None)
 
 

--- a/merlin/common/util_sampling.py
+++ b/merlin/common/util_sampling.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/utils.py
+++ b/merlin/config/utils.py
@@ -1,4 +1,5 @@
 import enum
+from typing import List
 
 from merlin.config.configfile import CONFIG
 
@@ -9,25 +10,33 @@ class Priority(enum.Enum):
     low = 3
 
 
-def get_priority(priority):
-    broker = CONFIG.broker.name.lower()
-    priorities = [Priority.high, Priority.mid, Priority.low]
-    if priority not in priorities:
-        raise ValueError(
+def is_rabbit_broker(broker: str) -> bool:
+    return broker in ["rabbitmq", "amqps", "amqp"]
+
+
+def is_redis_broker(broker: str) -> bool:
+    return broker in ["redis", "rediss", "redis+socket"]
+
+
+def get_priority(priority: Priority) -> int:
+    broker: str = CONFIG.broker.name.lower()
+    priorities: List[Priority] = [Priority.high, Priority.mid, Priority.low]
+    if not isinstance(priority, Priority):
+        raise TypeError(
             f"Unrecognized priority '{priority}'! Priority enum options: {[x.name for x in priorities]}"
         )
     if priority == Priority.mid:
         return 5
-    if broker == "rabbitmq":
+    if is_rabbit_broker(broker):
         if priority == Priority.low:
             return 1
         if priority == Priority.high:
             return 10
-    if broker == "redis":
+    if is_redis_broker(broker):
         if priority == Priority.low:
             return 10
         if priority == Priority.high:
             return 1
     raise ValueError(
-        "Function get_priority has reached unknown state! Check input parameter and broker."
+        f"Function get_priority has reached unknown state! Maybe unsupported broker {broker}?"
     )

--- a/merlin/data/celery/__init__.py
+++ b/merlin/data/celery/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -190,5 +190,5 @@ def print_info(args):
         info_str += 'echo " $ ' + x + '" && ' + x + "\n"
         info_str += "echo \n"
     info_str += r"echo \"echo \$PYTHONPATH\" && echo $PYTHONPATH"
-    subprocess.call(info_str, shell=True)
+    _ = subprocess.run(info_str, shell=True)
     print("")

--- a/merlin/examples/__init__.py
+++ b/merlin/examples/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/examples.py
+++ b/merlin/examples/examples.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/generator.py
+++ b/merlin/examples/generator.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/workflows/flux/scripts/flux_info.py
+++ b/merlin/examples/workflows/flux/scripts/flux_info.py
@@ -23,6 +23,7 @@ done:
 import json
 import os
 import subprocess
+from typing import IO, Dict, Union
 
 import flux
 from flux import kvs
@@ -68,24 +69,28 @@ try:
 except BaseException:
     top_dir = "job"
 
-    def get_data_dict(key):
-        kwargs = {
+    def get_data_dict(key: str) -> Dict:
+        kwargs: Dict[str, Union[str, bool, os.Environ]] = {
             "env": os.environ,
             "shell": True,
             "universal_newlines": True,
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,
         }
-        flux_com = f"flux kvs get {key}"
-        p = subprocess.Popen(flux_com, **kwargs)
+        flux_com: str = f"flux kvs get {key}"
+        p: subprocess.Popen = subprocess.Popen(flux_com, **kwargs)
+        stdout: IO[str]
+        stderr: IO[str]
         stdout, stderr = p.communicate()
 
-        data = {}
-        for l in stdout.split("/n"):
-            for s in l.strip().split():
-                if "timestamp" in s:
-                    jstring = s.replace("'", '"')
-                    d = json.loads(jstring)
+        data: Dict = {}
+        line: str
+        for line in stdout.split("/n"):
+            token: str
+            for token in line.strip().split():
+                if "timestamp" in token:
+                    jstring: str = token.replace("'", '"')
+                    d: Dict = json.loads(jstring)
                     data[d["name"]] = d["timestamp"]
 
         return data

--- a/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
+++ b/merlin/examples/workflows/null_spec/scripts/launch_jobs.py
@@ -3,26 +3,30 @@ import os
 import shutil
 import socket
 import subprocess
+from typing import List
 
 
-parser = argparse.ArgumentParser(description="Launch 35 merlin workflow jobs")
+parser: argparse.ArgumentParser = argparse.ArgumentParser(
+    description="Launch 35 merlin workflow jobs"
+)
 parser.add_argument("run_id", type=int, help="The ID of this run")
 parser.add_argument("output_path", type=str, help="the output path")
 parser.add_argument("spec_path", type=str, help="path to the spec to run")
 parser.add_argument("script_path", type=str, help="path to the make samples script")
-args = parser.parse_args()
+args: argparse.Namespace = parser.parse_args()
 
-machine = socket.gethostbyaddr(socket.gethostname())[0]
+machine: str = socket.gethostbyaddr(socket.gethostname())[0]
 if "quartz" in machine:
     machine = "quartz"
 elif "pascal" in machine:
     machine = "pascal"
 
 # launch n_samples * n_conc merlin workflow jobs
-submit_path = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
-concurrencies = [2 ** 0, 2 ** 1, 2 ** 2, 2 ** 3, 2 ** 4, 2 ** 5, 2 ** 6]
-samples = [10 ** 1, 10 ** 2, 10 ** 3, 10 ** 4, 10 ** 5]
-nodes = []
+submit_path: str = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+concurrencies: List[int] = [2 ** 0, 2 ** 1, 2 ** 2, 2 ** 3, 2 ** 4, 2 ** 5, 2 ** 6]
+samples: List[int] = [10 ** 1, 10 ** 2, 10 ** 3, 10 ** 4, 10 ** 5]
+nodes: List = []
+c: int
 for c in concurrencies:
     if c > 32:
         nodes.append(int(c / 32))
@@ -35,22 +39,27 @@ for c in concurrencies:
 # concurrencies = [2 ** 3]
 # samples = [10 ** 5]
 
-output_path = os.path.join(args.output_path, f"run_{args.run_id}")
+output_path: str = os.path.join(args.output_path, f"run_{args.run_id}")
 os.makedirs(output_path, exist_ok=True)
-for i, concurrency in enumerate(concurrencies):
-    c_name = os.path.join(output_path, f"c_{concurrency}")
+ii: int
+concurrency: int
+for ii, concurrency in enumerate(concurrencies):
+    c_name: str = os.path.join(output_path, f"c_{concurrency}")
     if not os.path.isdir(c_name):
         os.mkdir(c_name)
     os.chdir(c_name)
-    for j, sample in enumerate(samples):
-        s_name = os.path.join(c_name, f"s_{sample}")
+    jj: int
+    sample: int
+    for jj, sample in enumerate(samples):
+        s_name: str = os.path.join(c_name, f"s_{sample}")
         if not os.path.isdir(s_name):
             os.mkdir(s_name)
         os.chdir(s_name)
         os.mkdir("scripts")
-        samp_per_worker = float(sample) / float(concurrency)
-        # if (samp_per_worker / 60) > times[j]:
-        #    print(f"c{concurrency}_s{sample} : {round(samp_per_worker / 60, 0)}m.\ttime: {times[j]}m.\tdiff: {round((samp_per_worker / 60) - times[j], 0)}m")
+        samp_per_worker: float = float(sample) / float(concurrency)
+        # if (samp_per_worker / 60) > times[jj]:
+        #    print(f"c{concurrency}_s{sample} : {round(samp_per_worker / 60, 0)}m.\ttime: {times[jj]}m.\tdiff: {round((samp_per_worker / 60) - times[jj], 0)}m")
+        real_time: int
         if (samp_per_worker / 60) < 1.0:
             real_time = 4
         elif (samp_per_worker / 60) < 3.0:
@@ -70,11 +79,11 @@ for i, concurrency in enumerate(concurrencies):
             partition = "pbatch"
         if real_time > 1440:
             real_time = 1440
-        submit = "submit.sbatch"
-        command = f"sbatch -J c{concurrency}s{sample}r{args.run_id} --time {real_time} -N {nodes[i]} -p {partition} -A {account} {submit} {sample} {int(concurrency/nodes[i])} {args.run_id} {concurrency}"
+        submit: str = "submit.sbatch"
+        command: str = f"sbatch -J c{concurrency}s{sample}r{args.run_id} --time {real_time} -N {nodes[ii]} -p {partition} -A {account} {submit} {sample} {int(concurrency/nodes[ii])} {args.run_id} {concurrency}"
         shutil.copyfile(os.path.join(submit_path, submit), submit)
         shutil.copyfile(args.spec_path, "spec.yaml")
         shutil.copyfile(args.script_path, os.path.join("scripts", "make_samples.py"))
-        lines = subprocess.check_output(command, shell=True).decode("ascii")
-        os.chdir(f"..")
-    os.chdir(f"..")
+        lines: str = subprocess.check_output(command, shell=True).decode("ascii")
+        os.chdir("..")
+    os.chdir("..")

--- a/merlin/exceptions/__init__.py
+++ b/merlin/exceptions/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/log_formatter.py
+++ b/merlin/log_formatter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/merlin_templates.py
+++ b/merlin/merlin_templates.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/__init__.py
+++ b/merlin/spec/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/defaults.py
+++ b/merlin/spec/defaults.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/expansion.py
+++ b/merlin/spec/expansion.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -35,6 +35,7 @@ To see examples of yaml specifications, run `merlin example`.
 """
 import logging
 import os
+import shlex
 from io import StringIO
 
 import yaml
@@ -123,11 +124,12 @@ class MerlinSpec(YAMLSpecification):
             merlin_block = yaml.safe_load(stream)["merlin"]
         except KeyError:
             merlin_block = {}
-            LOG.warning(
-                f"Workflow specification missing \n "
-                f"encouraged 'merlin' section! Run 'merlin example' for examples.\n"
-                f"Using default configuration with no sampling."
+            warning_msg: str = (
+                "Workflow specification missing \n "
+                "encouraged 'merlin' section! Run 'merlin example' for examples.\n"
+                "Using default configuration with no sampling."
             )
+            LOG.warning(warning_msg)
         return merlin_block
 
     def process_spec_defaults(self):
@@ -368,7 +370,7 @@ class MerlinSpec(YAMLSpecification):
         param steps: a list of step names
         """
         queues = ",".join(set(self.get_queue_list(steps)))
-        return f'"{queues}"'
+        return shlex.quote(queues)
 
     def get_worker_names(self):
         result = []

--- a/merlin/study/__init__.py
+++ b/merlin/study/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -37,6 +37,7 @@ are implemented.
 """
 import logging
 import os
+from typing import Dict, Optional, Union
 
 from merlin.utils import get_yaml_var
 
@@ -110,16 +111,21 @@ def get_node_count(default=1):
     return default
 
 
-def batch_worker_launch(spec, com, nodes=None, batch=None):
+def batch_worker_launch(
+    spec: Dict,
+    com: str,
+    nodes: Optional[Union[str, int]] = None,
+    batch: Optional[Dict] = None,
+) -> str:
     """
     The configuration in the batch section of the merlin spec
     is used to create the worker launch line, which may be
     different from a simulation launch.
 
-    com (str): The command to launch with batch configuration
-    nodes (int): The number of nodes to use in the batch launch
-    batch (dict): An optional batch override from the worker config
-
+    : param spec : (Dict) workflow specification
+    : param com : (str): The command to launch with batch configuration
+    : param nodes : (Optional[Union[str, int]]): The number of nodes to use in the batch launch
+    : param batch : (Optional[Dict]): An optional batch override from the worker config
     """
     if batch is None:
         try:
@@ -128,7 +134,7 @@ def batch_worker_launch(spec, com, nodes=None, batch=None):
             LOG.error("The batch section is required in the specification file.")
             raise
 
-    btype = get_yaml_var(batch, "type", "local")
+    btype: str = get_yaml_var(batch, "type", "local")
 
     # A jsrun submission cannot be run under a parent jsrun so
     # all non flux lsf submissions need to be local.
@@ -142,61 +148,77 @@ def batch_worker_launch(spec, com, nodes=None, batch=None):
     # Get the number of nodes from the environment if unset
     if nodes is None or nodes == "all":
         nodes = get_node_count(default=1)
+    elif not isinstance(nodes, int):
+        raise TypeError(
+            "Nodes was passed into batch_worker_launch with an invalid type (likely a string other than 'all')."
+        )
 
-    bank = get_yaml_var(batch, "bank", "")
-    queue = get_yaml_var(batch, "queue", "")
-    shell = get_yaml_var(batch, "shell", "bash")
-    walltime = get_yaml_var(batch, "walltime", "")
+    shell: str = get_yaml_var(batch, "shell", "bash")
 
-    launch_pre = get_yaml_var(batch, "launch_pre", "")
-    launch_args = get_yaml_var(batch, "launch_args", "")
-    worker_launch = get_yaml_var(batch, "worker_launch", "")
+    launch_pre: str = get_yaml_var(batch, "launch_pre", "")
+    launch_args: str = get_yaml_var(batch, "launch_args", "")
+    launch_command: str = get_yaml_var(batch, "worker_launch", "")
 
-    if btype == "flux":
-        launcher = get_batch_type()
-    else:
-        launcher = get_batch_type()
+    if not launch_command:
+        launch_command = construct_worker_launch_command(batch, btype, nodes)
 
-    launchs = worker_launch
-    if not launchs:
-        if btype == "slurm" or launcher == "slurm":
-            launchs = f"srun -N {nodes} -n {nodes}"
-            if bank:
-                launchs += f" -A {bank}"
-            if queue:
-                launchs += f" -p {queue}"
-            if walltime:
-                launchs += f" -t {walltime}"
-        if launcher == "lsf":
-            # The jsrun utility does not have a time argument
-            launchs = f"jsrun -a 1 -c ALL_CPUS -g ALL_GPUS --bind=none -n {nodes}"
-
-    launchs += f" {launch_args}"
+    launch_command += f" {launch_args}"
 
     # Allow for any pre launch manipulation, e.g. module load
     # hwloc/1.11.10-cuda
     if launch_pre:
-        launchs = f"{launch_pre} {launchs}"
+        launch_command = f"{launch_pre} {launch_command}"
 
-    worker_cmd = f"{launchs} {com}"
-
+    worker_cmd: str = ""
     if btype == "flux":
-        flux_path = get_yaml_var(batch, "flux_path", "")
-        flux_opts = get_yaml_var(batch, "flux_start_opts", "")
-        flux_exec_workers = get_yaml_var(batch, "flux_exec_workers", True)
+        flux_path: str = get_yaml_var(batch, "flux_path", "")
+        flux_opts: Union[str, Dict] = get_yaml_var(batch, "flux_start_opts", "")
+        flux_exec_workers: Union[str, Dict, bool] = get_yaml_var(
+            batch, "flux_exec_workers", True
+        )
 
-        flux_exec = ""
+        flux_exec: str = ""
         if flux_exec_workers:
             flux_exec = "flux exec"
 
         if "/" in flux_path:
             flux_path += "/"
 
-        flux_exe = os.path.join(flux_path, "flux")
+        flux_exe: str = os.path.join(flux_path, "flux")
 
-        launch = (
-            f"{launchs} {flux_exe} start {flux_opts} {flux_exec} `which {shell}` -c"
-        )
+        launch: str = f"{launch_command} {flux_exe} start {flux_opts} {flux_exec} `which {shell}` -c"
         worker_cmd = f'{launch} "{com}"'
+    else:
+        worker_cmd = f"{launch_command} {com}"
 
     return worker_cmd
+
+
+def construct_worker_launch_command(
+    batch: Optional[Dict], btype: str, nodes: int
+) -> str:
+    """
+    If no 'worker_launch' is found in the batch yaml, this method constructs the needed launch command.
+
+    : param batch : (Optional[Dict]): An optional batch override from the worker config
+    : param btype : (str): The type of batch (flux, local, lsf)
+    : param nodes : (int): The number of nodes to use in the batch launch
+    """
+    launch_command: str = ""
+    workload_manager: str = get_batch_type()
+    bank: str = get_yaml_var(batch, "bank", "")
+    queue: str = get_yaml_var(batch, "queue", "")
+    walltime: str = get_yaml_var(batch, "walltime", "")
+    if btype == "slurm" or workload_manager == "slurm":
+        launch_command = f"srun -N {nodes} -n {nodes}"
+        if bank:
+            launch_command += f" -A {bank}"
+        if queue:
+            launch_command += f" -p {queue}"
+        if walltime:
+            launch_command += f" -t {walltime}"
+    if workload_manager == "lsf":
+        # The jsrun utility does not have a time argument
+        launch_command = f"jsrun -a 1 -c ALL_CPUS -g ALL_GPUS --bind=none -n {nodes}"
+
+    return launch_command

--- a/merlin/study/dag.py
+++ b/merlin/study/dag.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/step.py
+++ b/merlin/study/step.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -386,15 +386,15 @@ def get_flux_version(flux_path, no_errors=False):
     except FileNotFoundError as e:
         if not no_errors:
             LOG.error(f"The flux path {flux_path} canot be found")
-            LOG.error(f"Suppress this error with no_errors=True")
+            LOG.error("Suppress this error with no_errors=True")
             raise e
 
     try:
         flux_ver = re.search(r"\s*([\d.]+)", ps[0]).group(1)
     except (ValueError, TypeError) as e:
         if not no_errors:
-            LOG.error(f"The flux version canot be determined")
-            LOG.error(f"Suppress this error with no_errors=True")
+            LOG.error("The flux version cannot be determined")
+            LOG.error("Suppress this error with no_errors=True")
             raise e
         else:
             flux_ver = DEFAULT_FLUX_VERSION

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ ignore = E203, E266, E501, W503
 max-line-length = 127
 max-complexity = 15
 select = B,C,E,F,W,T4
-exclude = .git,__pycache__,ascii_art.py,merlin/examples/*
+exclude = .git,__pycache__,ascii_art.py,merlin/examples/*,*venv*
 
 [mypy]
 files=best_practices,test

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -44,8 +44,9 @@ def readme():
 
 
 # The reqs code from celery setup.py
-def _strip_comments(l):
-    return l.split("#", 1)[0].strip()
+def _strip_comments(line: str):
+    """Removes comments from a line passed in from _reqs()."""
+    return line.split("#", 1)[0].strip()
 
 
 def _pip_requirement(req):
@@ -59,8 +60,8 @@ def _reqs(*f):
     return [
         _pip_requirement(r)
         for r in (
-            _strip_comments(l)
-            for l in open(os.path.join(os.getcwd(), "requirements", *f)).readlines()
+            _strip_comments(line)
+            for line in open(os.path.join(os.getcwd(), "requirements", *f)).readlines()
         )
         if r
     ]

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.8.0.
+# This file is part of Merlin, Version: 1.8.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -106,13 +106,10 @@ def process_test_result(passed, info, is_verbose, exit):
         print("pass")
 
     if info["violated_condition"] is not None:
-        message = info["violated_condition"][0]
-        condition_id = info["violated_condition"][1] + 1
-        n_conditions = info["violated_condition"][2]
-        print(
-            f"\tCondition {condition_id} of {n_conditions}: "
-            + str(info["violated_condition"][0])
-        )
+        msg: str = str(info["violated_condition"][0])
+        condition_id: str = info["violated_condition"][1] + 1
+        n_conditions: str = info["violated_condition"][2]
+        print(f"\tCondition {condition_id} of {n_conditions}: {msg}")
     if is_verbose is True:
         print(f"\tcommand: {info['command']}")
         print(f"\telapsed time: {round(info['total_time'], 2)} s")

--- a/tests/integration/test_definitions.py
+++ b/tests/integration/test_definitions.py
@@ -105,7 +105,7 @@ def define_tests():
         ),
     }
     example_tests = {
-        "example failure": (f"merlin example failure", HasRegex("not found"), "local"),
+        "example failure": ("merlin example failure", HasRegex("not found"), "local"),
         "example simple_chain": (
             f"merlin example simple_chain ; {run} simple_chain.yaml --local --vars OUTPUT_PATH=./{OUTPUT_DIR} ; rm simple_chain.yaml",
             HasReturnCode(),
@@ -217,13 +217,13 @@ def define_tests():
             [
                 HasReturnCode(),
                 ProvenanceYAMLFileHasRegex(
-                    regex="HELLO: \$\(SCRIPTS\)/hello_world.py",
+                    regex=r"HELLO: \$\(SCRIPTS\)/hello_world.py",
                     name="feature_demo",
                     output_path=OUTPUT_DIR,
                     provenance_type="orig",
                 ),
                 ProvenanceYAMLFileHasRegex(
-                    regex="name: \$\(NAME\)",
+                    regex=r"name: \$\(NAME\)",
                     name="feature_demo",
                     output_path=OUTPUT_DIR,
                     provenance_type="partial",
@@ -241,7 +241,7 @@ def define_tests():
                     provenance_type="expanded",
                 ),
                 ProvenanceYAMLFileHasRegex(
-                    regex="\$\(NAME\)",
+                    regex=r"\$\(NAME\)",
                     name="feature_demo",
                     output_path=OUTPUT_DIR,
                     provenance_type="expanded",
@@ -287,13 +287,13 @@ def define_tests():
             f"{run} {demo} --pgen {demo_pgen} --vars OUTPUT_PATH=./{OUTPUT_DIR} --local",
             [
                 ProvenanceYAMLFileHasRegex(
-                    regex="\[0.3333333",
+                    regex=r"\[0.3333333",
                     name="feature_demo",
                     output_path=OUTPUT_DIR,
                     provenance_type="expanded",
                 ),
                 ProvenanceYAMLFileHasRegex(
-                    regex="\[0.5",
+                    regex=r"\[0.5",
                     name="feature_demo",
                     output_path=OUTPUT_DIR,
                     provenance_type="expanded",
@@ -304,25 +304,25 @@ def define_tests():
             "local",
         ),
     }
-    provenence_equality_checks = {
+    provenence_equality_checks = {  # noqa: F841
         "local provenance spec equality": (
             f"{run} {simple} --vars OUTPUT_PATH=./{OUTPUT_DIR} --local ; cp $(find ./{OUTPUT_DIR}/simple_chain_*/merlin_info -type f -name 'simple_chain.expanded.yaml') ./{OUTPUT_DIR}/FILE1 ; rm -rf ./{OUTPUT_DIR}/simple_chain_* ; {run} ./{OUTPUT_DIR}/FILE1 --vars OUTPUT_PATH=./{OUTPUT_DIR} --local ; cmp ./{OUTPUT_DIR}/FILE1 $(find ./{OUTPUT_DIR}/simple_chain_*/merlin_info -type f -name 'simple_chain.expanded.yaml')",
             HasReturnCode(),
             "local",
         ),
     }
-    style_checks = {
+    style_checks = {  # noqa: F841
         "black check merlin": (f"{black} merlin/", HasReturnCode(), "local"),
         "black check tests": (f"{black} tests/", HasReturnCode(), "local"),
     }
     dependency_checks = {
         "deplic no GNU": (
-            f"deplic ./",
+            "deplic ./",
             [HasRegex("GNU", negate=True), HasRegex("GPL", negate=True)],
             "local",
         ),
     }
-    distributed_tests = {
+    distributed_tests = {  # noqa: F841
         "run and purge feature_demo": (
             f"{run} {demo} ; {purge} {demo} -f",
             HasReturnCode(),

--- a/tests/unit/common/test_sample_index.py
+++ b/tests/unit/common/test_sample_index.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import unittest
 from contextlib import suppress
 
 from merlin.common.sample_index_factory import create_hierarchy, read_hierarchy

--- a/tests/unit/study/test_study.py
+++ b/tests/unit/study/test_study.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import unittest
 
+import pytest
+
 from merlin.study.step import Step
 from merlin.study.study import MerlinStudy
 
@@ -148,6 +150,7 @@ merlin:
 """
 
 
+# TODO many of these more resemble integration tests than unit tests, may want to review unit tests to make it more granular.
 def test_get_task_queue_default():
     """
     Given a steps dictionary that sets the task queue to `test_queue` return
@@ -277,27 +280,36 @@ class TestMerlinStudy(unittest.TestCase):
         If there is a common key between Maestro's global.parameters and
         Merlin's sample/column_labels, an error should be raised.
         """
-        merlin_spec_conflict = os.path.join(self.tmpdir, "basic_ensemble_conflict.yaml")
+        merlin_spec_conflict: str = os.path.join(
+            self.tmpdir, "basic_ensemble_conflict.yaml"
+        )
         with open(merlin_spec_conflict, "w+") as _file:
             _file.write(MERLIN_SPEC_CONFLICT)
-        try:
-            study_conflict = MerlinStudy(merlin_spec_conflict)
-        except ValueError:
-            pass
-        else:
-            assert False
+        # for some reason flake8 doesn't believe variables instantiated inside the try/with context are assigned
+        with pytest.raises(ValueError):
+            study_conflict: MerlinStudy = MerlinStudy(merlin_spec_conflict)
+            assert (
+                not study_conflict
+            ), "study_conflict completed construction without raising a ValueError."
 
+    # TODO the pertinent attribute for study_no_env should be examined and asserted to be empty
     def test_no_env(self):
         """
         A MerlinStudy should be able to support a MerlinSpec that does not contain
         the optional `env` section.
         """
-        merlin_spec_no_env_filepath = os.path.join(
+        merlin_spec_no_env_filepath: str = os.path.join(
             self.tmpdir, "basic_ensemble_no_env.yaml"
         )
         with open(merlin_spec_no_env_filepath, "w+") as _file:
             _file.write(MERLIN_SPEC_NO_ENV)
         try:
-            study_no_env = MerlinStudy(merlin_spec_no_env_filepath)
+            study_no_env: MerlinStudy = MerlinStudy(merlin_spec_no_env_filepath)
+            bad_type_err: str = (
+                f"study_no_env failed construction, is type {type(study_no_env)}."
+            )
+            assert isinstance(study_no_env, MerlinStudy), bad_type_err
         except Exception as e:
-            assert False
+            assert (
+                False
+            ), f"Encountered unexpected exception, {e}, for viable MerlinSpec without optional 'env' section."


### PR DESCRIPTION
* Re-added support for all brokers with task priority (#324)

* Re-added support for all brokers with task priority

* Bugfix for merlin purge (#327)

* Bugfix for merlin purge

* Address reviewer comments

* Refactor of Merlin internals and CI to be flake8 compliant (#326)

* Refactored source to be flake8 compliant. Many changes are cosmetic/style focused - to spacing, removing unused vars, using r strings, etc. Notable changes which *could* have changed behavior included pulling out a considerable chunk of batch_worker_launch into a subfunction, construct_worker_launch_command. Added typing to most of the files touched by the flake8 refactor (any that were missed will be caught in the PyLint refactor). 

* The Makefile was updated in a few ways - generally cleaned up to be a bit neater (so targets are defined approx. as they're encountered/needed in a workflow), a few targets were added (one to check the whole CI pipeline before pushing), the testing targets were updated to activate the venv before running the test suites.

Co-authored-by: Alexander Cameron Winter <winter27@quartz1148.llnl.gov>

* Release work: reformatting via Black, version update, minor test change. (#329)

Reformatted source using Black to be PEP compliant. Updated version number to 1.8.1. Minor modification to unit testing for test_no_env and test_column_conflict - this removed an unnecessary Flake8 stepover by using PyTest and examining test objects more thoroughly.

Co-authored-by: Alexander Cameron Winter <winter27@quartz1148.llnl.gov>

Co-authored-by: Luc Peterson <peterson76@llnl.gov>
Co-authored-by: Alexander Cameron Winter <winter27@quartz1148.llnl.gov>