### PR TITLE
Resolve merge-conflict preventing 1.8.2 release

### DIFF
--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -81,7 +81,6 @@ access among all of them.
      print a.dtype      # dtype of array
 
 """
-
 from typing import List, Tuple
 
 import numpy as np


### PR DESCRIPTION
The release of 1.8.2 was held up because of a divergence between [main and develop that was preventing a smooth merger](https://github.com/LLNL/merlin/pull/341), which would have effectively been merging 1.8.2 to 1.8.0 (and so on until fixed - 1.8.3 would've then had to be merged to 1.8.0, etc, each time drifting further).

Merging this will unblock the release of 1.8.2. It "cleans" the git history without forcing any downstream forks to go through any nasty rebasing and re-enable the merger of central_fork/develop -> central_fork/main once this is merged from AlexanderWinter_fork/develop -> central_fork/develo . However, merging this does effectively "unzip" the squash done to release 1.8.1 (while still holding that commit), so the file diff will look extremely long. The diff should still be examined closely, as it was a lengthier merge-conflict to resolve.