### PR TITLE
Add support for non-merlin blocks in specification file

### DIFF
--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -143,10 +143,6 @@ class MerlinSpec(YAMLSpecification):
             user_block = yaml.safe_load(stream)["user"]
         except KeyError:
             user_block = {}
-            warning_msg: str = (
-                "user specification missing"
-            )
-            LOG.warning(warning_msg)
         return user_block
 
     def process_spec_defaults(self):
@@ -289,7 +285,7 @@ class MerlinSpec(YAMLSpecification):
         list_offset = 2 * " "
         if isinstance(obj, list):
             n = len(obj)
-            use_hyphens = key_stack[-1] in ["paths", "sources", "git", "study"]
+            use_hyphens = key_stack[-1] in ["paths", "sources", "git", "study"] or key_stack[0] in ["user"]
             if not use_hyphens:
                 string += "["
             else:


### PR DESCRIPTION
Adding capability for non-user blocks of yaml code to be included in the merlin specification, and propegated to the .partial and .expanded versions at runtime. This allows the users to define yaml specifications for steps in the workflow in the same file, and for user code to perform consistency checks between the merlin spec and code in the steps - for example, checking consistency between variable names, etc.

A new "user" block has been added to the `MerlinSpec` class in `spec/specification.py`. The `user` block is not included in any checking and does not have default values. The yaml code has shell and merlin parameters substituted and is copied to the working directories verbatim. 

Changelog:

- Added a static method `load_user_block` to the `MerlinSpec` class, which loads the `user` block from the yaml specification and returns the python representation
- In functions `load_specification` and `load_spec_from_string`, added definitions of `self.user` through calls to `load_user_block`
- In the `yaml_sections` and `sections` properties, added references to `self.user`
- In the `dict_to_string` method of `MerlinSpec` object, add `user` block support for pretty printing of lists

When no `user` block is present in the yaml file, the `MerlinSpec.user` attribute is an empty dictionary

Test Functionality:

- correct generation of problems in `merlin` test problems (with `-clean` option)
- correct generation of problems and variable substitution when a `user` block is added to the test problems (with `-clean` option)
- complete execution of `merlin` test problems