### PR TITLE
Addition of new shortcuts in specification file

### DIFF
--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -107,6 +107,11 @@ class MerlinStudy:
             "MERLIN_SOFT_FAIL": str(int(ReturnCode.SOFT_FAIL)),
             "MERLIN_HARD_FAIL": str(int(ReturnCode.HARD_FAIL)),
             "MERLIN_RETRY": str(int(ReturnCode.RETRY)),
+            "MERLIN_ALL_SAMPLES": " ".join(self.get_sample_labels(from_spec=self.original_spec)),
+            "MERLIN_SPEC": os.path.join(
+                    self.info,
+                    self.original_spec.description["name"].replace(" ", "_") + ".expanded.yaml"
+            )
         }
 
         self.pgen_file = pgen_file
@@ -182,6 +187,11 @@ class MerlinStudy:
             return self.load_samples()
         return []
 
+    def get_sample_labels(self, from_spec):
+        if from_spec.merlin["samples"]:
+            return from_spec.merlin["samples"]["column_labels"]
+        return []
+
     @property
     def sample_labels(self):
         """
@@ -197,9 +207,7 @@ class MerlinStudy:
 
         :return: list of labels (e.g. ["X0", "X1"] )
         """
-        if self.expanded_spec.merlin["samples"]:
-            return self.expanded_spec.merlin["samples"]["column_labels"]
-        return []
+        return self.get_sample_labels(from_spec=self.expanded_spec)
 
     def load_samples(self):
         """

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -107,7 +107,9 @@ class MerlinStudy:
             "MERLIN_SOFT_FAIL": str(int(ReturnCode.SOFT_FAIL)),
             "MERLIN_HARD_FAIL": str(int(ReturnCode.HARD_FAIL)),
             "MERLIN_RETRY": str(int(ReturnCode.RETRY)),
-            "MERLIN_ALL_SAMPLES": " ".join([ "$({})".format(k) for k in self.get_sample_labels(from_spec=self.original_spec)]),
+            # below will be substituted for sample values on execution
+            "MERLIN_SAMPLE_VECTOR": " ".join([ "$({})".format(k) for k in self.get_sample_labels(from_spec=self.original_spec)]),
+            "MERLIN_SAMPLE_NAMES": " ".join(self.get_sample_labels(from_spec=self.original_spec)),
             "MERLIN_SPEC": os.path.join(
                     self.info,
                     self.original_spec.description["name"].replace(" ", "_") + ".expanded.yaml"

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -107,7 +107,7 @@ class MerlinStudy:
             "MERLIN_SOFT_FAIL": str(int(ReturnCode.SOFT_FAIL)),
             "MERLIN_HARD_FAIL": str(int(ReturnCode.HARD_FAIL)),
             "MERLIN_RETRY": str(int(ReturnCode.RETRY)),
-            "MERLIN_ALL_SAMPLES": " ".join(self.get_sample_labels(from_spec=self.original_spec)),
+            "MERLIN_ALL_SAMPLES": " ".join([ "$({})".format(k) for k in self.get_sample_labels(from_spec=self.original_spec)]),
             "MERLIN_SPEC": os.path.join(
                     self.info,
                     self.original_spec.description["name"].replace(" ", "_") + ".expanded.yaml"


### PR DESCRIPTION
Adding three new shortcuts to the specification definition:

`$(MERLIN_SAMPLE_VECTOR)` is substituted for `"$(SAMPLE_COLUMN_1) $(SAMPLE_COLUMN_2) ..."`
`$(MERLIN_SAMPLE_NAMES)` is substituted for `"SAMPLE_COLUMN_1 SAMPLE_COLUMN_2 ..."`
`$(MERLIN_SPEC)` is substituted for the path to the `*.expanded.yaml` file in the `merlin_info` directory

Changelog:

- In the `special_vars` method of the `MerlinStudy` class, add reference and definitions of the new shortcuts
- Added new method `get_sample_labels` to `MerlinStudy` class. This generalizes the existing `sample_labels` property to allow the labels to be read from a user-specified `MerlinSpec` instance. This is needed to avoid access to the `expanded_spec` property before `special_vars` are defined, which causes an `AttributeError`
- Update to existing `sample_labels` property to be consistent with new `get_sample_labels` method

Tests Performed:

- Successful generation and run of "hello world" example script
- Successful generate and run of existing distributed workflow modified to use new shortcuts