### PR TITLE
Ssl server check fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New shortcuts in specification file (sample_vector, sample_names, spec_original_template, spec_executed_run, spec_archived_copy)
 - Changed "default" user password to be "merlin_password" as default.
 - Update requirements to require redis 4.3.4 for acl user channel support
+- Added ssl to the broker and results backend server checks when "merlin info" is called
 
 ### Fixed
 - Fixed return values from scripts with main() to fix testing errors. 

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -88,7 +88,12 @@ def check_server_access(sconf):
 def _examine_connection(s, sconf, excpts):
     connect_timeout = 60
     try:
-        conn = Connection(sconf[s])
+        ssl_conf = None
+        if "broker" in s:
+            ssl_conf = broker.get_ssl_config()
+        if "results" in s:
+            ssl_conf = results_backend.get_ssl_config()
+        conn = Connection(sconf[s], ssl=ssl_conf)
         conn_check = ConnProcess(target=conn.connect)
         conn_check.start()
         counter = 0


### PR DESCRIPTION
This will fix launchit rabbitmq server check issue. The server is actually working, but the check will fail when merlin info is run.