### PR TITLE
Refactor query-workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_step_worker_map()` as a method in `specification.py`
 - Added `tabulate_info()` function in `display.py` to help with table formatting
 - Added get_flux_alloc function for new flux version >= 0.48.x interface change
+- New flags to the `query-workers` command
+  - `--queues`: query workers based on the queues they're associated with
+  - `--workers`: query workers based on a regex of the names you're looking for
+  - `--spec`: query workers based on the workers defined in a spec file
 
 ### Changed
 - Changed celery_regex to celery_slurm_regex in test_definitions.py
@@ -73,7 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added a function `construct_scheduler_legend` to build a dict that keeps as much information as we need about each scheduler stored in one place
   - Cleaned up the `construct_worker_launch_command` function to utilize the newly added functions and decrease the amount of repeated code
 - Changed get_flux_cmd for new flux version >=0.48.x interface
-
+- The `query-workers` command now prints a table as its' output
+  - Each row of the `Workers` column has the name of an active worker
+  - Each row of the `Queues` column has a list of queues associated with the active worker
 
 ## [1.9.1]
 ### Fixed

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -257,6 +257,12 @@ How do I see what workers are connected?
 
    $ merlin query-workers
 
+This command gives you fine control over which workers you're looking for via
+a regex on their name, the queue names associated with workers, or even by providing
+the name of a spec file where workers are defined.
+
+For more info, see :ref:`query-workers`.
+
 How do I stop workers?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/merlin_commands.rst
+++ b/docs/source/merlin_commands.rst
@@ -174,6 +174,8 @@ the input yaml file.
 ``Example: --vars QUEUE_NAME=new_queue EPOCHS=3``
 
 
+.. _query-workers:
+
 Searching for any workers (``merlin query-workers``)
 ----------------------------------------------------
 
@@ -185,8 +187,43 @@ the task server you can use:
     $ merlin query-workers
 
 This will broadcast a command to all connected workers and print
-the names of any that respond. This is useful for interacting
-with workers, such as via ``merlin stop-workers --workers``.
+the names of any that respond and the queues they're attached to.
+This is useful for interacting with workers, such as via
+``merlin stop-workers --workers``.
+
+The ``--queues`` option will look for workers associated with the
+names of the queues you provide here. For example, if you want to
+see the names of all workers attached to the queues named ``demo``
+and ``merlin`` you would use:
+
+.. code-block::
+
+    merlin query-workers --queues demo merlin
+
+The ``--spec`` option will query for workers defined in the spec
+file you provide. For example, if ``simworker`` and ``nonsimworker``
+are defined in a spec file called ``example_spec.yaml`` then to query
+for these workers you would use:
+
+.. code-block::
+
+    merlin query-workers --spec example_spec.yaml
+
+The ``--workers`` option will query for workers based on the worker
+names you provide here. For example, if you wanted to query a worker
+named ``step_1_worker`` you would use:
+
+.. code-block::
+
+    merlin query-workers --workers step_1_worker
+
+This flag can also take regular expressions as input. For instance,
+if you had several workers running but only wanted to find the workers
+whose names started with ``step`` you would use:
+
+.. code-block::
+
+    merlin query-workers --workers ^step
 
 
 Restart the workflow (``merlin restart``)

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -160,7 +160,7 @@ def dump_status(query_return, csv_file):
         f.write("\n")
 
 
-def query_workers(task_server):
+def query_workers(task_server, spec_worker_names, queues, workers_regex):
     """
     Gets info from workers.
 
@@ -169,7 +169,7 @@ def query_workers(task_server):
     LOG.info("Searching for workers...")
 
     if task_server == "celery":
-        query_celery_workers()
+        query_celery_workers(spec_worker_names, queues, workers_regex)
     else:
         LOG.error("Celery is not specified as the task server!")
 

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -185,6 +185,26 @@ def regex_list_filter(regex, list_to_filter, match=True):
     return list(filter(r.search, list_to_filter))
 
 
+def apply_list_of_regex(regex_list, list_to_filter, result_list, match=False):
+    """
+    Take a list of regex's, apply each regex to a list we're searching through,
+    and append each result to a result list.
+
+    :param `regex_list`: A list of regular expressions to apply to the list_to_filter
+    :param `list_to_filter`: A list that we'll apply regexs to
+    :param `result_list`: A list that we'll append results of the regex filters to
+    :param `match`: A bool where when true we use re.match for applying the regex,
+                    when false we use re.search for applying the regex.
+    """
+    for regex in regex_list:
+        filter_results = set(regex_list_filter(regex, list_to_filter, match))
+
+        if not filter_results:
+            LOG.warning(f"No regex match for {regex}.")
+        else:
+            result_list += filter_results
+
+
 def load_yaml(filepath):
     """
     Safely read a yaml file.

--- a/tests/integration/test_definitions.py
+++ b/tests/integration/test_definitions.py
@@ -103,6 +103,8 @@ def define_tests():  # pylint: disable=R0914,R0915
     run = f"merlin {err_lvl} run"
     restart = f"merlin {err_lvl} restart"
     purge = "merlin purge"
+    stop = "merlin stop-workers"
+    query = "merlin query-workers"
 
     # Shortcuts for example workflow paths
     examples = "merlin/examples/workflows"
@@ -515,7 +517,7 @@ def define_tests():  # pylint: disable=R0914,R0915
     }
     stop_workers_tests = {
         "stop workers no workers": {
-            "cmds": "merlin stop-workers",
+            "cmds": f"{stop}",
             "conditions": [
                 HasReturnCode(),
                 HasRegex("No workers found to stop"),
@@ -528,7 +530,7 @@ def define_tests():  # pylint: disable=R0914,R0915
         "stop workers no flags": {
             "cmds": [
                 f"{workers} {mul_workers_demo}",
-                "merlin stop-workers",
+                f"{stop}",
             ],
             "conditions": [
                 HasReturnCode(),
@@ -544,7 +546,7 @@ def define_tests():  # pylint: disable=R0914,R0915
         "stop workers with spec flag": {
             "cmds": [
                 f"{workers} {mul_workers_demo}",
-                f"merlin stop-workers --spec {mul_workers_demo}",
+                f"{stop} --spec {mul_workers_demo}",
             ],
             "conditions": [
                 HasReturnCode(),
@@ -560,7 +562,7 @@ def define_tests():  # pylint: disable=R0914,R0915
         "stop workers with workers flag": {
             "cmds": [
                 f"{workers} {mul_workers_demo}",
-                "merlin stop-workers --workers step_1_merlin_test_worker step_2_merlin_test_worker",
+                f"{stop} --workers step_1_merlin_test_worker step_2_merlin_test_worker",
             ],
             "conditions": [
                 HasReturnCode(),
@@ -576,11 +578,88 @@ def define_tests():  # pylint: disable=R0914,R0915
         "stop workers with queues flag": {
             "cmds": [
                 f"{workers} {mul_workers_demo}",
-                "merlin stop-workers --queues hello_queue",
+                f"{stop} --queues hello_queue",
             ],
             "conditions": [
                 HasReturnCode(),
                 HasRegex("No workers found to stop", negate=True),
+                HasRegex("step_1_merlin_test_worker"),
+                HasRegex("step_2_merlin_test_worker", negate=True),
+                HasRegex("other_merlin_test_worker", negate=True),
+            ],
+            "run type": "distributed",
+            "cleanup": KILL_WORKERS,
+            "num procs": 2,
+        },
+    }
+    query_workers_tests = {
+        "query workers no workers": {
+            "cmds": f"{query}",
+            "conditions": [
+                HasReturnCode(),
+                HasRegex("No workers found!"),
+                HasRegex("step_1_merlin_test_worker", negate=True),
+                HasRegex("step_2_merlin_test_worker", negate=True),
+                HasRegex("other_merlin_test_worker", negate=True),
+            ],
+            "run type": "distributed",
+        },
+        "query workers no flags": {
+            "cmds": [
+                f"{workers} {mul_workers_demo}",
+                f"{query}",
+            ],
+            "conditions": [
+                HasReturnCode(),
+                HasRegex("No workers found!", negate=True),
+                HasRegex("step_1_merlin_test_worker"),
+                HasRegex("step_2_merlin_test_worker"),
+                HasRegex("other_merlin_test_worker"),
+            ],
+            "run type": "distributed",
+            "cleanup": KILL_WORKERS,
+            "num procs": 2,
+        },
+        "query workers with spec flag": {
+            "cmds": [
+                f"{workers} {mul_workers_demo}",
+                f"{query} --spec {mul_workers_demo}",
+            ],
+            "conditions": [
+                HasReturnCode(),
+                HasRegex("No workers found!", negate=True),
+                HasRegex("step_1_merlin_test_worker"),
+                HasRegex("step_2_merlin_test_worker"),
+                HasRegex("other_merlin_test_worker"),
+            ],
+            "run type": "distributed",
+            "cleanup": KILL_WORKERS,
+            "num procs": 2,
+        },
+        "query workers with workers flag": {
+            "cmds": [
+                f"{workers} {mul_workers_demo}",
+                f"{query} --workers step_1_merlin_test_worker step_2_merlin_test_worker",
+            ],
+            "conditions": [
+                HasReturnCode(),
+                HasRegex("No workers found!", negate=True),
+                HasRegex("step_1_merlin_test_worker"),
+                HasRegex("step_2_merlin_test_worker"),
+                HasRegex("other_merlin_test_worker", negate=True),
+            ],
+            "run type": "distributed",
+            "cleanup": KILL_WORKERS,
+            "num procs": 2,
+        },
+        "query workers with queues flag": {
+            "cmds": [
+                f"{workers} {mul_workers_demo}",
+                f"{query} --queues hello_queue",
+            ],
+            "conditions": [
+                HasReturnCode(),
+                HasRegex("No workers found!", negate=True),
                 HasRegex("step_1_merlin_test_worker"),
                 HasRegex("step_2_merlin_test_worker", negate=True),
                 HasRegex("other_merlin_test_worker", negate=True),
@@ -637,6 +716,7 @@ def define_tests():  # pylint: disable=R0914,R0915
         # style_checks, # omitting style checks due to different results on different machines
         dependency_checks,
         stop_workers_tests,
+        query_workers_tests,
         distributed_tests,
     ]:
         all_tests.update(test_dict)


### PR DESCRIPTION
This branch was created based on a suggestion by Dylan Cliche. It adds 3 flags to `query-workers` that follow similar logic to `stop-workers`:
1. `--queues`: enables users to provide certain queues to query workers from
2. `--spec`: enables users to query workers from certain spec files
3. `--workers`: enables users to query workers by worker name (or regex)

Additionally, the output of this command has been changed from logging the worker names that are found to printing a table of workers and their associated queues.
