### PR TITLE
release/1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.10.1]
 ### Fixed
 - A bug where assigning a worker all steps also assigned steps to the default worker
 
 ### Added
 - Tests to make sure the default worker is being assigned properly
+
+### Changed
+- Requirement name in examples/workflows/remote_feature_demo/requirements.txt and examples/workflows/feature_demo/requirements.txt from sklearn to scikit-learn since sklearn is now deprecated
 
 ## [1.10.0]
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #
@@ -38,7 +38,7 @@ import os
 import sys
 
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 VERSION = __version__
 PATH_TO_PROJ = os.path.join(os.path.dirname(__file__), "")
 

--- a/merlin/ascii_art.py
+++ b/merlin/ascii_art.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/celery.py
+++ b/merlin/celery.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/__init__.py
+++ b/merlin/common/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/__init__.py
+++ b/merlin/common/abstracts/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/abstracts/enums/__init__.py
+++ b/merlin/common/abstracts/enums/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/openfilelist.py
+++ b/merlin/common/openfilelist.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/opennpylib.py
+++ b/merlin/common/opennpylib.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/sample_index.py
+++ b/merlin/common/sample_index.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/sample_index_factory.py
+++ b/merlin/common/sample_index_factory.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/__init__.py
+++ b/merlin/common/security/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt.py
+++ b/merlin/common/security/encrypt.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/security/encrypt_backend_traffic.py
+++ b/merlin/common/security/encrypt_backend_traffic.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/common/util_sampling.py
+++ b/merlin/common/util_sampling.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/__init__.py
+++ b/merlin/config/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/celeryconfig.py
+++ b/merlin/config/celeryconfig.py
@@ -10,7 +10,7 @@ Default celery configuration for merlin
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/configfile.py
+++ b/merlin/config/configfile.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/config/utils.py
+++ b/merlin/config/utils.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/data/celery/__init__.py
+++ b/merlin/data/celery/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/__init__.py
+++ b/merlin/examples/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/examples.py
+++ b/merlin/examples/examples.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/generator.py
+++ b/merlin/examples/generator.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/examples/workflows/feature_demo/requirements.txt
+++ b/merlin/examples/workflows/feature_demo/requirements.txt
@@ -1,2 +1,2 @@
-sklearn
+scikit-learn
 merlin-spellbook

--- a/merlin/examples/workflows/remote_feature_demo/requirements.txt
+++ b/merlin/examples/workflows/remote_feature_demo/requirements.txt
@@ -1,2 +1,2 @@
-sklearn
+scikit-learn
 merlin-spellbook

--- a/merlin/exceptions/__init__.py
+++ b/merlin/exceptions/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/log_formatter.py
+++ b/merlin/log_formatter.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/main.py
+++ b/merlin/main.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/merlin_templates.py
+++ b/merlin/merlin_templates.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/router.py
+++ b/merlin/router.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/server/__init__.py
+++ b/merlin/server/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 
 #
 # For details, see https://github.com/LLNL/merlin.

--- a/merlin/server/server_commands.py
+++ b/merlin/server/server_commands.py
@@ -8,7 +8,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/server/server_config.py
+++ b/merlin/server/server_config.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/server/server_util.py
+++ b/merlin/server/server_util.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/__init__.py
+++ b/merlin/spec/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/defaults.py
+++ b/merlin/spec/defaults.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/expansion.py
+++ b/merlin/spec/expansion.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/override.py
+++ b/merlin/spec/override.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/spec/specification.py
+++ b/merlin/spec/specification.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/__init__.py
+++ b/merlin/study/__init__.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/dag.py
+++ b/merlin/study/dag.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/script_adapter.py
+++ b/merlin/study/script_adapter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/step.py
+++ b/merlin/study/step.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/study/study.py
+++ b/merlin/study/study.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/tests/integration/conditions.py
+++ b/tests/integration/conditions.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #

--- a/tests/integration/test_definitions.py
+++ b/tests/integration/test_definitions.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin, Version: 1.10.0.
+# This file is part of Merlin, Version: 1.10.1.
 #
 # For details, see https://github.com/LLNL/merlin.
 #


### PR DESCRIPTION
Bumped version to 1.10.1. This version includes:

- Bugfix for when the default worker is started when it shouldn't be
- Fix for a deprecated requirement in remote_feature_demo and feature_demo
  - sklearn -> scikit-learn