### PR TITLE
fix permission denied error with check_for_scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A bug where the openfoam_wf_singularity example was not being found
 - Some build warnings in the docs (unknown targets, duplicate targets, title underlines too short, etc.)
 - A bug where when the output path contained a variable that was overridden, the overridden variable was not changed in the output_path
+- A bug where permission denied errors happened when checking for system scheduler
 
 ### Added
 - Tests for ensuring `$(MERLIN_SPEC_ORIGINAL_TEMPLATE)`, `$(MERLIN_SPEC_ARCHIVED_COPY)`, and `$(MERLIN_SPEC_EXECUTED_RUN)` are stored correctly

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -92,7 +92,7 @@ def check_for_scheduler(scheduler, scheduler_legend):
         if result and len(result) > 0 and scheduler_legend[scheduler]["expected check output"] in result[0]:
             return True
         return False
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         return False
 
 


### PR DESCRIPTION
This fixes #435. We now catch both FileNotFound and PermissionErrors instead of just FNF.