### PR TITLE
dependabot/certifi-requests-pygments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+
+### Added
+
+### Changed
+- Bump certifi from 2022.12.7 to 2023.7.22 in /docs
+- Bump pygments from 2.13.0 to 2.15.0 in /docs
+- Bump requests from 2.28.1 to 2.31.0 in /docs
+
 ## [1.10.2]
 ### Fixed
 - A bug where the .orig, .partial, and .expanded file names were using the study name rather than the original file name

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
-certifi==2022.12.7
+certifi==2023.7.22
     # via requests
 charset-normalizer==2.1.1
     # via requests

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,13 +26,13 @@ markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via sphinx
-pygments==2.13.0
+pygments==2.15.0
     # via sphinx
 pyparsing==3.0.9
     # via packaging
 pytz==2022.5
     # via babel
-requests==2.28.1
+requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx


### PR DESCRIPTION
These are the changes from the last 3 dependabot PRs that have yet to be merged. I was going to wait to do these until I could get a github action set up to automatically update the CHANGELOG but seeing as there's a security concern with the certifi bump, I think these should just be merged ASAP. I'll work on the github action for future dependabot PRs instead.