### PR TITLE
bugfix/server-pip-redis-conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- The *.conf regex for the recursive-include of the merlin server directory so that pip will add it to the wheel
+- A note to the docs for how to fix an issue where the `merlin server start` command hangs
 
 ### Changed
 - Bump certifi from 2022.12.7 to 2023.7.22 in /docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include merlin/data *.yaml *.py
-recursive-include merlin/server *.yaml *.py
+recursive-include merlin/server *.yaml *.py *.conf
 recursive-include merlin/examples *
 include requirements.txt
 include requirements/*

--- a/docs/source/merlin_server.rst
+++ b/docs/source/merlin_server.rst
@@ -1,7 +1,7 @@
 Merlin Server
 =============
 The merlin server command allows users easy access to containerized broker 
-and results servers for merlin workflows. This allowsusers to run merlin without
+and results servers for merlin workflows. This allows users to run merlin without
 a dedicated external server.
 
 The main configuration will be stored in the subdirectory called "server/" by 

--- a/docs/source/server/commands.rst
+++ b/docs/source/server/commands.rst
@@ -38,7 +38,7 @@ Starts the container located in the local merlin server configuration.
     If this command seems to hang and never release control back to you, follow these steps:
 
     1. Kill the command with ``Ctrl+C``
-    2. Run ``export LC_ALL="C.UTF-8"``
+    2. Run either ``export LC_ALL="C.UTF-8"`` or ``export LC_ALL="C"``
     3. Re-run the ``merlin server start`` command
 
 Stopping an exisiting Merlin Server (``merlin server stop``)

--- a/docs/source/server/commands.rst
+++ b/docs/source/server/commands.rst
@@ -34,6 +34,13 @@ Starting up a Merlin Server (``merlin server start``)
 
 Starts the container located in the local merlin server configuration.
 
+.. note::
+    If this command seems to hang and never release control back to you, follow these steps:
+
+    1. Kill the command with ``Ctrl+C``
+    2. Run ``export LC_ALL="C.UTF-8"``
+    3. Re-run the ``merlin server start`` command
+
 Stopping an exisiting Merlin Server (``merlin server stop``)
 ------------------------------------------------------------
 


### PR DESCRIPTION
I added the *.conf to the recursive-include of the merlin server folder so that pip will add the redis.conf file to the wheel. I've also added a note on explaining how to fix an issue with `merlin server start` to get it to stop hanging.