### PR TITLE
bugfix/lsf-gpu-typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Typo in `batch.py` that caused lsf launches to fail (`ALL_SGPUS` changed to `ALL_GPUS`)
+
 ## [1.11.0]
 ### Added
 - New reserved variable:

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -299,7 +299,7 @@ def construct_scheduler_legend(parsed_batch: Dict, nodes: int) -> Dict:
         "lsf": {
             "check cmd": ["jsrun", "--help"],
             "expected check output": b"jsrun",
-            "launch": f"jsrun -a 1 -c ALL_CPUS -g ALL_SGPUS --bind=none -n {nodes}",
+            "launch": f"jsrun -a 1 -c ALL_CPUS -g ALL_GPUS --bind=none -n {nodes}",
         },
         # pbs is mainly a placeholder in case a user wants to try it (we don't have it at the lab so it's mostly untested)
         "pbs": {
@@ -335,11 +335,15 @@ def construct_worker_launch_command(parsed_batch: Dict, nodes: int) -> str:
     scheduler_legend: Dict = construct_scheduler_legend(parsed_batch, nodes)
     workload_manager: str = get_batch_type(scheduler_legend)
 
+    print(f"parsed_batch: {parsed_batch}")
+
     if parsed_batch["btype"] == "pbs" and workload_manager == parsed_batch["btype"]:
         raise TypeError("The PBS scheduler is only enabled for 'batch: flux' type")
 
     if parsed_batch["btype"] == "slurm" and workload_manager not in ("lsf", "flux", "pbs"):
         workload_manager = "slurm"
+
+    print(f"workload_manager: {workload_manager}")
 
     try:
         launch_command = scheduler_legend[workload_manager]["launch"]

--- a/merlin/study/batch.py
+++ b/merlin/study/batch.py
@@ -335,7 +335,7 @@ def construct_worker_launch_command(parsed_batch: Dict, nodes: int) -> str:
     scheduler_legend: Dict = construct_scheduler_legend(parsed_batch, nodes)
     workload_manager: str = get_batch_type(scheduler_legend)
 
-    print(f"parsed_batch: {parsed_batch}")
+    LOG.debug(f"parsed_batch: {parsed_batch}")
 
     if parsed_batch["btype"] == "pbs" and workload_manager == parsed_batch["btype"]:
         raise TypeError("The PBS scheduler is only enabled for 'batch: flux' type")
@@ -343,7 +343,7 @@ def construct_worker_launch_command(parsed_batch: Dict, nodes: int) -> str:
     if parsed_batch["btype"] == "slurm" and workload_manager not in ("lsf", "flux", "pbs"):
         workload_manager = "slurm"
 
-    print(f"workload_manager: {workload_manager}")
+    LOG.debug(f"workload_manager: {workload_manager}")
 
     try:
         launch_command = scheduler_legend[workload_manager]["launch"]


### PR DESCRIPTION
There was a typo in `batch.py` that resulted in worker launch failures on blueos machines for workflows that try to use flux. This branch fixes that typo.