### PR TITLE
Improved Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pytest-mock as a dependency for the test suite (necessary for using mocks and fixtures in the same test)
 
 ### Changed
+- `merlin info` is cleaner and gives python package info
+- merlin version now prints with every banner message
 
 ### Fixed
 - Bugfix for output of `merlin example openfoam_wf_singularity`

--- a/merlin/ascii_art.py
+++ b/merlin/ascii_art.py
@@ -30,6 +30,8 @@
 
 # pylint: skip-file
 
+from merlin import VERSION
+
 """
 Holds ascii art strings.
 """
@@ -127,6 +129,7 @@ def _make_banner():
     for hat_line, name_line in zip(hat_lines, name_lines):
         banner = banner + hat_line + name_line + "\n"
 
+    banner = banner + f"  v. {VERSION}\n"
     return banner
 
 

--- a/merlin/ascii_art.py
+++ b/merlin/ascii_art.py
@@ -32,6 +32,7 @@
 
 from merlin import VERSION
 
+
 """
 Holds ascii art strings.
 """

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -32,6 +32,7 @@
 Manages formatting for displaying information to the console.
 """
 import logging
+import os
 import pprint
 import shutil
 import subprocess
@@ -46,6 +47,7 @@ from tabulate import tabulate
 
 from merlin.ascii_art import banner_small
 from merlin.study.status_renderers import status_renderer_factory
+from merlin.utils import get_package_versions
 
 
 LOG = logging.getLogger("merlin")
@@ -212,9 +214,9 @@ def display_multiple_configs(files, configs):
 # Might use args here in the future so we'll disable the pylint warning for now
 def print_info(args):  # pylint: disable=W0613
     """
-    Provide version and location information about python and pip to
-    facilitate user troubleshooting. 'merlin info' is a CLI tool only for
-    developer versions of Merlin.
+    Provide version and location information about python and packages to
+    facilitate user troubleshooting. Also provides info about server connections
+    and configurations.
 
     :param `args`: parsed CLI arguments
     """
@@ -225,14 +227,11 @@ def print_info(args):  # pylint: disable=W0613
     print("Python Configuration")
     print("-" * 25)
     print("")
-    info_calls = ["which python3", "python3 --version", "which pip3", "pip3 --version"]
-    info_str = ""
-    for cmd in info_calls:
-        info_str += 'echo " $ ' + cmd + '" && ' + cmd + "\n"
-        info_str += "echo \n"
-    info_str += r"echo \"echo \$PYTHONPATH\" && echo $PYTHONPATH"
-    _ = subprocess.run(info_str, shell=True)
-    print("")
+    package_list = ["pip", "merlin", "maestrowf", "celery", "kombu", "amqp", "redis"]
+    package_versions = get_package_versions(package_list)
+    print(package_versions)
+    pythonpath = os.environ.get("PYTHONPATH")
+    print(f"$PYTHONPATH: {pythonpath}")
 
 
 def display_status_task_by_task(status_obj: "DetailedStatus", test_mode: bool = False):  # noqa: F821

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -37,6 +37,7 @@ import os
 import re
 import socket
 import subprocess
+import sys
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -44,8 +45,10 @@ from types import SimpleNamespace
 from typing import Callable, List, Optional, Union
 
 import numpy as np
+import pkg_resources
 import psutil
 import yaml
+from tabulate import tabulate
 
 
 try:
@@ -744,3 +747,26 @@ def ws_time_to_dt(ws_time: str) -> datetime:
     minute = int(ws_time[11:13])
     second = int(ws_time[13:])
     return datetime(year, month, day, hour=hour, minute=minute, second=second)
+
+
+def get_package_versions(package_list: List[str]) -> str:
+    """
+    Return a table of the versions and locations of installed packages, including python.
+    If the package is not installed says "Not installed"
+
+    :param `package_list`: A list of packages.
+    :returns: A string that's a formatted table.
+    """
+    table = []
+    for package in package_list:
+        try:
+            distribution = pkg_resources.get_distribution(package)
+            version = distribution.version
+            location = distribution.location
+            table.append([package, version, location])
+        except pkg_resources.DistributionNotFound:
+            table.append([package, "Not installed", "N/A"])
+
+    table.insert(0, ["python", sys.version.split()[0], sys.executable])
+    table_str = tabulate(table, headers=["Package", "Version", "Location"], tablefmt="simple")
+    return f"Python Packages\n\n{table_str}\n"

--- a/tests/unit/utils/test_get_package_version.py
+++ b/tests/unit/utils/test_get_package_version.py
@@ -1,0 +1,56 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+from tabulate import tabulate
+
+from merlin.utils import get_package_versions
+
+
+fake_package_list = [
+    ("python", sys.version.split()[0], sys.executable),
+    ("merlin", "1.2.3", "/path/to/merlin"),
+    ("celery", "4.5.1", "/path/to/celery"),
+    ("kombu", "4.6.11", "/path/to/kombu"),
+    ("redis", "3.5.3", "/path/to/redis"),
+    ("amqp", "2.6.1", "/path/to/amqp"),
+]
+
+
+@pytest.fixture
+def mock_get_distribution():
+    """Mock call to get python distribution"""
+    with patch("pkg_resources.get_distribution") as mock_get_distribution:
+        mock_get_distribution.side_effect = [mock_distribution(*package) for package in fake_package_list[1:]]
+        yield mock_get_distribution
+
+
+class mock_distribution:
+    """A mock python distribution"""
+
+    def __init__(self, package, version, location):
+        self.key = package
+        self.version = version
+        self.location = location
+
+
+def test_get_package_versions(mock_get_distribution):
+    """Test ability to get versions and format as correct table"""
+    package_list = ["merlin", "celery", "kombu", "redis", "amqp"]
+    fake_table = tabulate(fake_package_list, headers=["Package", "Version", "Location"], tablefmt="simple")
+    expected_result = f"Python Packages\n\n{fake_table}\n"
+    result = get_package_versions(package_list)
+    assert result == expected_result
+
+
+def test_bad_package():
+    """Test that it only gets the things we have in our real environment."""
+    bogus_packages = ["garbage_package_1", "junk_package_2"]
+    result = get_package_versions(bogus_packages)
+    expected_data = [fake_package_list[0]]  # python
+    for package in bogus_packages:
+        expected_data.append([package, "Not installed", "N/A"])
+
+    expected_table = tabulate(expected_data, headers=["Package", "Version", "Location"], tablefmt="simple")
+    expected_result = f"Python Packages\n\n{expected_table}\n"
+    assert result == expected_result


### PR DESCRIPTION
This PR provides users with more information when running merlin.
Now, the merlin version is printed every time the 'hat' banner is displayed (several commands print this). This auto-logs the version for users.
Also, `merlin info` is cleaner and displays python package info versions and locations.
Example output from new `merlin info` command:

```
(merlin3_10) ruby964{lucpeter}357: merlin info
  
                                                
       *      
   *~~~~~                                       
  *~~*~~~*      __  __           _ _       
 /   ~~~~~     |  \/  |         | (_)      
     ~~~~~     | \  / | ___ _ __| |_ _ __  
    ~~~~~*     | |\/| |/ _ \ '__| | | '_ \ 
   *~~~~~~~    | |  | |  __/ |  | | | | | |
  ~~~~~~~~~~   |_|  |_|\___|_|  |_|_|_| |_|
 *~~~~~~~~~~~                                    
   ~~~*~~~*    Machine Learning for HPC Workflows                                 
              

  v. 1.12.1

[2024-05-15 17:52:02: INFO] Reading app config from file /g/g15/lucpeter/.merlin/app.yaml
Merlin Configuration
-------------------------

 config_file        | /g/g15/lucpeter/.merlin/app.yaml
 is_debug           | False
 merlin_home        | /g/g15/lucpeter/.merlin
 merlin_home_exists | True
 broker server      | amqps://lucpeter:******@jackalope.llnl.gov:5671/lucpeter
 broker ssl         | True
 results server     | redis://mlsi:******@jackalope.llnl.gov:6379/0
 results ssl        | False

Checking server connections:
----------------------------
broker server connection: OK
results server connection: OK

Python Configuration
-------------------------

Python Packages

Package    Version    Location
---------  ---------  -------------------------------------------------------------------------
python     3.10.8     /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/bin/python3
pip        24.0       /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
merlin     1.12.1     /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
maestrowf  1.1.10     /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
celery     5.3.6      /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
kombu      5.3.5      /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
amqp       5.2.0      /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages
redis      5.0.3      /usr/WS1/lucpeter/merlin/venv_merlin_py_3_10/lib/python3.10/site-packages

$PYTHONPATH: None

```