### PR TITLE
Target is in source's history

### DIFF
--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -14,6 +14,15 @@ jobs:
       with:
         fetch-depth: 0 # Checkout the whole history, in case the target is way far behind
 
+    - name: Check if target branch has been merged
+      run: |
+        if git merge-base --is-ancestor ${{ github.event.pull_request.base.sha }} ${{ github.sha }}; then
+          echo "Target branch has been merged into the source branch."
+        else
+          echo "Target branch has not been merged into the source branch. Please merge in target first."
+          exit 1
+        fi
+
     - name: Check that CHANGELOG has been updated
       run: |
         # If this step fails, this means you haven't updated the CHANGELOG.md file with notes on your contribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tests for reading and writing status files, and status conflict handling
 - Added tests for the `dict_deep_merge` function
 - Pytest-mock as a dependency for the test suite (necessary for using mocks and fixtures in the same test)
+- New github action test to make sure target branch has been merged into the source first, so we know histories are ok
 
 ### Changed
 - `merlin info` is cleaner and gives python package info


### PR DESCRIPTION
Adds a GitHub action to check that the target branch is in the history of the source branch. This implies that the source is downstream of the target and it's valid to compare them. This should help catch future errors involve CHANGELOG comparisons