### PR TITLE
Requirements fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added "Unit-tests" GitHub action to run the unit test suite
 - Added `CeleryTaskManager` context manager to the test suite to ensure tasks are safely purged from queues if tests fail
 - Added `command-tests`, `workflow-tests`, and `integration-tests` to the Makefile
+- Python 3.8 now requires `orderly-set==5.3.0` to avoid a bug with the deepdiff library
 
 ### Changed
 - Dropped support for Python 3.7

--- a/merlin/config/broker.py
+++ b/merlin/config/broker.py
@@ -37,14 +37,9 @@ import os
 import ssl
 from os.path import expanduser
 from typing import Dict, List, Optional, Union
+from urllib.parse import quote
 
 from merlin.config.configfile import CONFIG, get_ssl_entries
-
-
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
 
 
 LOG: logging.Logger = logging.getLogger(__name__)

--- a/merlin/config/results_backend.py
+++ b/merlin/config/results_backend.py
@@ -35,14 +35,9 @@ from __future__ import print_function
 
 import logging
 import os
+from urllib.parse import quote
 
 from merlin.config.configfile import CONFIG, get_ssl_entries
-
-
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
 
 
 LOG = logging.getLogger(__name__)

--- a/merlin/server/server_config.py
+++ b/merlin/server/server_config.py
@@ -35,6 +35,7 @@ import os
 import random
 import string
 import subprocess
+from importlib import resources
 from io import BufferedReader
 from typing import Tuple
 
@@ -50,12 +51,6 @@ from merlin.server.server_util import (
     RedisUsers,
     ServerConfig,
 )
-
-
-try:
-    from importlib import resources
-except ImportError:
-    import importlib_resources as resources
 
 
 LOG = logging.getLogger("merlin")

--- a/merlin/utils.py
+++ b/merlin/utils.py
@@ -34,6 +34,7 @@ Module for project-wide utility functions.
 import getpass
 import logging
 import os
+import pickle
 import re
 import socket
 import subprocess
@@ -49,12 +50,6 @@ import pkg_resources
 import psutil
 import yaml
 from tabulate import tabulate
-
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 
 LOG = logging.getLogger(__name__)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,5 +12,6 @@ sphinx>=2.0.0
 alabaster
 johnnydep
 deepdiff
+orderly-set==5.3.0; python_version == '3.8'
 pytest-order
 pytest-mock

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -2,8 +2,6 @@ cached_property
 celery[redis,sqlalchemy]>=5.0.3
 coloredlogs
 cryptography
-importlib_metadata<5.0.0; python_version == '3.7'
-importlib_resources; python_version < '3.7'
 maestrowf>=1.1.9dev1
 numpy
 parse

--- a/tests/unit/server/test_server_config.py
+++ b/tests/unit/server/test_server_config.py
@@ -6,6 +6,7 @@ import io
 import logging
 import os
 import string
+from importlib import resources
 from typing import Dict, Tuple, Union
 
 import pytest
@@ -28,12 +29,6 @@ from merlin.server.server_config import (
     pull_server_image,
 )
 from merlin.server.server_util import CONTAINER_TYPES, MERLIN_SERVER_SUBDIR, ServerConfig
-
-
-try:
-    from importlib import resources
-except ImportError:
-    import importlib_resources as resources
 
 
 def test_generate_password_no_pass_command():


### PR DESCRIPTION
The DeepDiff library recently released version 5.4.2 which is breaking the unit tests for python 3.8. This branch resolves that issue.

Additionally, I noticed some requirements were specific to python 3.7 and below. Since support for 3.7 and below is dropped, these requirements have been removed. That goes for unnecessary try/except import statements as well.