### PR TITLE
fix an issue with docs build on python 3.9

### DIFF
--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -241,12 +241,23 @@ jobs:
 
     - name: Reinstall pip to avoid vendored package corruption
       run: |
-        curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        PY_VER=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        PY_MAJOR=$(echo $PY_VER | cut -d. -f1)
+        PY_MINOR=$(echo $PY_VER | cut -d. -f2)
+
+        if [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -le 8 ]; then
+          URL="https://bootstrap.pypa.io/pip/${PY_VER}/get-pip.py"
+        else
+          URL="https://bootstrap.pypa.io/get-pip.py"
+        fi
+
+        curl -sS "$URL" -o get-pip.py
         python get-pip.py --force-reinstall
+
+        pip --version
   
     - name: Install dependencies
       run: |
-        pip --version
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -52,6 +52,23 @@ jobs:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
 
+    - name: Reinstall pip to avoid vendored package corruption
+      run: |
+        PY_VER=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        PY_MAJOR=$(echo $PY_VER | cut -d. -f1)
+        PY_MINOR=$(echo $PY_VER | cut -d. -f2)
+
+        if [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -le 8 ]; then
+          URL="https://bootstrap.pypa.io/pip/${PY_VER}/get-pip.py"
+        else
+          URL="https://bootstrap.pypa.io/get-pip.py"
+        fi
+
+        curl -sS "$URL" -o get-pip.py
+        python get-pip.py --force-reinstall
+
+        pip --version
+
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
@@ -106,6 +123,23 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+
+    - name: Reinstall pip to avoid vendored package corruption
+      run: |
+        PY_VER=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        PY_MAJOR=$(echo $PY_VER | cut -d. -f1)
+        PY_MINOR=$(echo $PY_VER | cut -d. -f2)
+
+        if [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -le 8 ]; then
+          URL="https://bootstrap.pypa.io/pip/${PY_VER}/get-pip.py"
+        else
+          URL="https://bootstrap.pypa.io/get-pip.py"
+        fi
+
+        curl -sS "$URL" -o get-pip.py
+        python get-pip.py --force-reinstall
+
+        pip --version
 
     - name: Install dependencies
       run: |
@@ -172,6 +206,23 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+
+    - name: Reinstall pip to avoid vendored package corruption
+      run: |
+        PY_VER=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+        PY_MAJOR=$(echo $PY_VER | cut -d. -f1)
+        PY_MINOR=$(echo $PY_VER | cut -d. -f2)
+
+        if [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -le 8 ]; then
+          URL="https://bootstrap.pypa.io/pip/${PY_VER}/get-pip.py"
+        else
+          URL="https://bootstrap.pypa.io/get-pip.py"
+        fi
+
+        curl -sS "$URL" -o get-pip.py
+        python get-pip.py --force-reinstall
+
+        pip --version
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -239,8 +239,14 @@ jobs:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/release.txt') }}-${{ hashFiles('requirements/dev.txt') }}
 
+    - name: Reinstall pip to avoid vendored package corruption
+      run: |
+        curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        python get-pip.py --force-reinstall
+  
     - name: Install dependencies
       run: |
+        pip --version
         python3 -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip3 install -r requirements/dev.txt

--- a/.github/workflows/push-pr_workflow.yml
+++ b/.github/workflows/push-pr_workflow.yml
@@ -64,8 +64,8 @@ jobs:
           URL="https://bootstrap.pypa.io/get-pip.py"
         fi
 
-        curl -sS "$URL" -o get-pip.py
-        python get-pip.py --force-reinstall
+        curl -sS "$URL" -o /tmp/get-pip.py
+        python /tmp/get-pip.py --force-reinstall
 
         pip --version
 
@@ -136,8 +136,8 @@ jobs:
           URL="https://bootstrap.pypa.io/get-pip.py"
         fi
 
-        curl -sS "$URL" -o get-pip.py
-        python get-pip.py --force-reinstall
+        curl -sS "$URL" -o /tmp/get-pip.py
+        python /tmp/get-pip.py --force-reinstall
 
         pip --version
 
@@ -219,8 +219,8 @@ jobs:
           URL="https://bootstrap.pypa.io/get-pip.py"
         fi
 
-        curl -sS "$URL" -o get-pip.py
-        python get-pip.py --force-reinstall
+        curl -sS "$URL" -o /tmp/get-pip.py
+        python /tmp/get-pip.py --force-reinstall
 
         pip --version
 
@@ -302,8 +302,8 @@ jobs:
           URL="https://bootstrap.pypa.io/get-pip.py"
         fi
 
-        curl -sS "$URL" -o get-pip.py
-        python get-pip.py --force-reinstall
+        curl -sS "$URL" -o /tmp/get-pip.py
+        python /tmp/get-pip.py --force-reinstall
 
         pip --version
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CeleryTaskManager` context manager to the test suite to ensure tasks are safely purged from queues if tests fail
 - Added `command-tests`, `workflow-tests`, and `integration-tests` to the Makefile
 - Python 3.8 now requires `orderly-set==5.3.0` to avoid a bug with the deepdiff library
+- New step 'Reinstall pip to avoid vendored package corruption' to CI workflow jobs that use pip
 
 ### Changed
 - Dropped support for Python 3.7

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -17,7 +17,7 @@ IGNORE_PATTERNS = [
 def should_ignore(path):
     """Check if the given path matches any ignore patterns."""
     for pattern in IGNORE_PATTERNS:
-        # if Path(pattern).is_relative_to(path):
+        pattern = str(pattern)
         if path.is_relative_to(Path(pattern)):
             return True
         if path.match(pattern):

--- a/merlin/common/security/encrypt_backend_traffic.py
+++ b/merlin/common/security/encrypt_backend_traffic.py
@@ -55,10 +55,6 @@ def _encrypt_encode(*args, **kwargs) -> bytes:
     This function wraps the original encode method, encrypting the result
     after encoding.
 
-    Args:
-        *args: Positional arguments passed to the original encode method.
-        **kwargs: Keyword arguments passed to the original encode method.
-
     Returns:
         The encrypted encoded data in bytes format.
     """

--- a/merlin/study/celeryadapter.py
+++ b/merlin/study/celeryadapter.py
@@ -421,7 +421,7 @@ def dump_celery_queue_info(query_return: List[Tuple[str, int, int]], dump_file: 
     dump_handler(dump_file, dump_info)
 
 
-def _get_specific_queues(queues: Set[str], specific_queues: List[str], spec: MerlinSpec, verbose=True) -> Set[str]:
+def _get_specific_queues(queues: Set[str], specific_queues: List[str], spec: MerlinSpec, verbose: bool = True) -> Set[str]:
     """
     Retrieve a set of specific queues requested by the user, filtering out those that do not exist.
 


### PR DESCRIPTION
Lina was telling me that the docs build was failing for the WEAVE CI. This happens because the WEAVE CI is using Python 3.9 and `PosixPath` does not yet have support for subscripting. The solution was to just convert `PosixPath` strings to built-in strings where this is breaking.

I also fixed 2 warnings that the griffe library was throwing at me when building the documentation.

UPDATE: I had to add a fix for pip in the CI since their latest update caused vendor package corruption.