### PR TITLE
refactor/factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Unit tests for the `spec/` folder
 - A page in the docs explaining the `feature_demo` example
+- New `MerlinBaseFactory` class to help enable future plugins for backends, monitors, status renderers, etc.
+
+### Changed
+- Maestro version requirement is now at minimum 1.1.10 for status renderer changes
+- The `BackendFactory`, `MonitorFactory`, and `StatusRendererFactory` classes all now inherit from `MerlinBaseFactory`
 
 ## [1.13.0b2]
 ### Added

--- a/merlin/abstracts/__init__.py
+++ b/merlin/abstracts/__init__.py
@@ -14,4 +14,5 @@ Modules:
 
 from merlin.abstracts.factory import MerlinBaseFactory
 
+
 __all__ = ["MerlinBaseFactory"]

--- a/merlin/abstracts/__init__.py
+++ b/merlin/abstracts/__init__.py
@@ -11,3 +11,7 @@ Merlin's codebase.
 Modules:
     factory: Contains `MerlinBaseFactory`, used to manage pluggable components in Merlin.
 """
+
+from merlin.abstracts.factory import MerlinBaseFactory
+
+__all__ = ["MerlinBaseFactory"]

--- a/merlin/abstracts/__init__.py
+++ b/merlin/abstracts/__init__.py
@@ -1,0 +1,13 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other Merlin
+# Project developers. See top-level LICENSE and COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Merlin.
+##############################################################################
+
+"""
+The `abstracts` package provides ABC classes that can be used throughout
+Merlin's codebase.
+
+Modules:
+    factory: Contains `MerlinBaseFactory`, used to manage pluggable components in Merlin.
+"""

--- a/merlin/abstracts/factory.py
+++ b/merlin/abstracts/factory.py
@@ -247,7 +247,8 @@ class MerlinBaseFactory(ABC):
         component_class = self._registry.get(canonical_name)
         if component_class is None:
             available = ", ".join(self.list_available())
-            raise ValueError(
+            error_cls = self._get_component_error_class()
+            raise error_cls(
                 f"Component '{component_type}' is not supported. "
                 f"Available components: {available}"
             )

--- a/merlin/abstracts/factory.py
+++ b/merlin/abstracts/factory.py
@@ -1,0 +1,225 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other Merlin
+# Project developers. See top-level LICENSE and COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Merlin.
+##############################################################################
+
+"""
+Base factory class for managing pluggable components in Merlin.
+
+This module defines an abstract `MerlinBaseFactory` class that provides a reusable
+infrastructure for registering, discovering, and instantiating pluggable components.
+It supports alias resolution, entry-point-based plugin discovery, and runtime
+introspection of registered components.
+
+Subclasses must define how to register built-in components, validate component classes,
+and identify the appropriate entry point group for plugin discovery.
+"""
+
+import logging
+import pkg_resources
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+LOG = logging.getLogger("merlin")
+
+
+class MerlinBaseFactory(ABC):
+    """
+    Abstract base factory for managing and instantiating pluggable components.
+
+    This class provides the infrastructure for:
+    - Registering components and their aliases
+    - Discovering plugins via Python entry points
+    - Creating instances of registered components
+    - Listing and introspecting available components
+
+    Subclasses are required to:
+        - Implement `_register_builtins()` to register default implementations
+        - Implement `_validate_component()` to enforce interface/type constraints
+        - Define `_entry_point_group()` to identify the entry point namespace for discovery
+
+    Attributes:
+        _registry (Dict[str, Any]): Maps canonical component names to their classes.
+        _aliases (Dict[str, str]): Maps alias names to canonical component names.
+
+    Methods:
+        register: Register a new component and its optional aliases.
+        list_available: Return a list of all registered component names.
+        create: Instantiate a registered component by name or alias.
+        get_component_info: Return introspection metadata for a registered component.
+        _discover_plugins: Discover and register plugin components using entry points.
+        _register_builtins: Abstract method for registering built-in/default components.
+        _validate_component: Abstract method for enforcing type/interface constraints.
+        _entry_point_group: Abstract method for returning the entry point namespace.
+    """
+
+    def __init__(self):
+        """
+        Initialize the base factory.
+
+        This base class provides common functionality for managing
+        a registry of available implementations and any aliases for them.
+        Subclasses can extend this to register built-in or default items.
+        """
+        # Map canonical names to implementation classes or instances
+        self._registry: Dict[str, Any] = {}
+
+        # Map aliases to canonical names (e.g., legacy names or shorthand)
+        self._aliases: Dict[str, str] = {}
+
+        # Register built-in implementations, if any
+        self._register_builtins()
+
+    @abstractmethod
+    def _register_builtins(self) -> None:
+        """
+        Register built-in components.
+
+        Subclasses must implement this to register relevant components.
+        """
+        raise NotImplementedError("Subclasses of `MerlinBaseFactory` must implement a `_register_builtins` method.")
+
+    @abstractmethod
+    def _validate_component(self, component_class: Any) -> None:
+        """
+        Validate the component class before registration.
+
+        Subclasses must implement this to enforce type or interface constraints.
+
+        Raises:
+            TypeError: If `component_class` is not valid.
+        """
+        raise NotImplementedError("Subclasses of `MerlinBaseFactory` must implement a `_validate_component` method.")
+    
+    @abstractmethod
+    def _entry_point_group(self) -> str:
+        """
+        Return the entry point group used for plugin discovery.
+
+        Subclasses must override this.
+        """
+        raise NotImplementedError("Subclasses must define an entry point group.")
+
+    def _discover_plugins(self):
+        """
+        Discover and register plugin components via entry points.
+
+        Subclasses can override this to support more discovery mechanisms.
+        """
+        try:
+            for entry_point in pkg_resources.iter_entry_points(self._entry_point_group()):
+                try:
+                    plugin_class = entry_point.load()
+                    self.register(entry_point.name, plugin_class)
+                    LOG.info(f"Loaded plugin: {entry_point.name}")
+                except Exception as e:
+                    LOG.warning(f"Failed to load plugin '{entry_point.name}': {e}")
+        except ImportError:
+            LOG.debug("pkg_resources not available for plugin discovery")
+
+    def register(self, name: str, component_class: Any, aliases: List[str] = None) -> None:
+        """
+        Register a new component implementation.
+
+        Args:
+            name: Canonical name for the component.
+            component_class: The class or implementation to register.
+            aliases: Optional alternative names for this component.
+
+        Raises:
+            TypeError: If the component_class fails validation.
+        """
+        self._validate_component(component_class)
+
+        self._registry[name] = component_class
+        LOG.debug(f"Registered component: {name}")
+
+        if aliases:
+            for alias in aliases:
+                self._aliases[alias] = name
+                LOG.debug(f"Registered alias '{alias}' for component '{name}'")
+
+    def list_available(self) -> List[str]:
+        """
+        Return a list of supported component names.
+
+        This includes both built-in and dynamically discovered components.
+
+        Returns:
+            A list of canonical names for all available components.
+        """
+        self._discover_plugins()
+        return list(self._registry.keys())
+
+    def create(self, component_type: str, config: Dict = None) -> Any:
+        """
+        Instantiate and return a component of the specified type.
+
+        Args:
+            component_type: The name or alias of the component to create.
+            config: Optional configuration for initializing the component.
+
+        Returns:
+            An instance of the requested component.
+
+        Raises:
+            ValueError: If the component is not registered or instantiation fails.
+        """
+        # Resolve alias
+        canonical_name = self._aliases.get(component_type, component_type)
+
+        # Discover plugins if needed
+        if canonical_name not in self._registry:
+            self._discover_plugins()
+
+        component_class = self._registry.get(canonical_name)
+        if component_class is None:
+            available = ", ".join(self.list_available())
+            raise ValueError(
+                f"Component '{component_type}' is not supported. "
+                f"Available components: {available}"
+            )
+
+        try:
+            instance = component_class() if config is None else component_class(**config)
+            LOG.info(f"Created component '{canonical_name}'")
+            return instance
+        except Exception as e:
+            raise ValueError(
+                f"Failed to create component '{canonical_name}': {e}"
+            ) from e
+
+    def get_component_info(self, component_type: str) -> Dict:
+        """
+        Get introspection information about a registered component.
+
+        Args:
+            component_type: The name or alias of the component.
+
+        Returns:
+            Dictionary containing metadata such as name, class, module, and docstring.
+
+        Raises:
+            ValueError: If the component is not registered.
+        """
+        canonical_name = self._aliases.get(component_type, component_type)
+
+        if canonical_name not in self._registry:
+            self._discover_plugins()
+
+        component_class = self._registry.get(canonical_name)
+        if component_class is None:
+            available = ", ".join(self.list_available())
+            raise ValueError(
+                f"Component '{component_type}' is not supported. "
+                f"Available components: {available}"
+            )
+
+        return {
+            "name": canonical_name,
+            "class": component_class.__name__,
+            "module": component_class.__module__,
+            "description": component_class.__doc__ or "No description available",
+        }

--- a/merlin/abstracts/factory.py
+++ b/merlin/abstracts/factory.py
@@ -17,9 +17,10 @@ and identify the appropriate entry point group for plugin discovery.
 """
 
 import logging
-import pkg_resources
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List
+
+import pkg_resources
 
 
 LOG = logging.getLogger("merlin")
@@ -95,7 +96,7 @@ class MerlinBaseFactory(ABC):
             TypeError: If `component_class` is not valid.
         """
         raise NotImplementedError("Subclasses of `MerlinBaseFactory` must implement a `_validate_component` method.")
-    
+
     @abstractmethod
     def _entry_point_group(self) -> str:
         """
@@ -107,7 +108,7 @@ class MerlinBaseFactory(ABC):
             The entry point group used for plugin discovery.
         """
         raise NotImplementedError("Subclasses must define an entry point group.")
-    
+
     def _discover_plugins_via_entry_points(self):
         """
         Discover and register plugins via Python entry points.
@@ -118,7 +119,7 @@ class MerlinBaseFactory(ABC):
                     plugin_class = entry_point.load()
                     self.register(entry_point.name, plugin_class)
                     LOG.info(f"Loaded plugin via entry point: {entry_point.name}")
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-exception-caught
                     LOG.warning(f"Failed to load plugin '{entry_point.name}': {e}")
         except ImportError:
             LOG.debug("pkg_resources not available for plugin discovery")
@@ -131,7 +132,6 @@ class MerlinBaseFactory(ABC):
 
         Subclasses can override this method to implement package/module scanning.
         """
-        pass
 
     def _discover_plugins(self):
         """
@@ -212,19 +212,14 @@ class MerlinBaseFactory(ABC):
         if component_class is None:
             available = ", ".join(self.list_available())
             error_cls = self._get_component_error_class()
-            raise error_cls(
-                f"Component '{component_type}' is not supported. "
-                f"Available components: {available}"
-            )
+            raise error_cls(f"Component '{component_type}' is not supported. " f"Available components: {available}")
 
         try:
             instance = component_class() if config is None else component_class(**config)
             LOG.info(f"Created component '{canonical_name}'")
             return instance
         except Exception as e:
-            raise ValueError(
-                f"Failed to create component '{canonical_name}': {e}"
-            ) from e
+            raise ValueError(f"Failed to create component '{canonical_name}': {e}") from e
 
     def get_component_info(self, component_type: str) -> Dict:
         """
@@ -248,10 +243,7 @@ class MerlinBaseFactory(ABC):
         if component_class is None:
             available = ", ".join(self.list_available())
             error_cls = self._get_component_error_class()
-            raise error_cls(
-                f"Component '{component_type}' is not supported. "
-                f"Available components: {available}"
-            )
+            raise error_cls(f"Component '{component_type}' is not supported. " f"Available components: {available}")
 
         return {
             "name": canonical_name,

--- a/merlin/backends/backend_factory.py
+++ b/merlin/backends/backend_factory.py
@@ -73,7 +73,7 @@ class MerlinBackendFactory(MerlinBaseFactory):
             The entry point namespace for Merlin backend plugins.
         """
         return "merlin.backends"
-    
+
     def _get_component_error_class(self) -> type[Exception]:
         """
         Return the exception type to raise for unsupported components.

--- a/merlin/backends/redis/redis_backend.py
+++ b/merlin/backends/redis/redis_backend.py
@@ -63,19 +63,18 @@ class RedisBackend(ResultsBackend):
             Delete an entity from the specified store.
     """
 
-    def __init__(self, backend_name: str):
+    def __init__(self):
         """
         Initialize the `RedisBackend` instance, setting up the Redis client connection and store mappings.
-
-        Args:
-            backend_name (str): The name of the backend (e.g., "redis").
         """
         from merlin.config.configfile import CONFIG  # pylint: disable=import-outside-toplevel
         from merlin.config.results_backend import get_connection_string  # pylint: disable=import-outside-toplevel
 
+        backend_name = CONFIG.results_backend.name
+
         # Get the Redis client connection
         redis_config = {"url": get_connection_string(), "decode_responses": True}
-        if CONFIG.results_backend.name == "rediss":
+        if backend_name == "rediss":
             redis_config.update({"ssl_cert_reqs": getattr(CONFIG.results_backend, "cert_reqs", "required")})
         self.client: Redis = Redis.from_url(**redis_config)
 

--- a/merlin/backends/sqlite/sqlite_backend.py
+++ b/merlin/backends/sqlite/sqlite_backend.py
@@ -58,12 +58,9 @@ class SQLiteBackend(ResultsBackend):
             Delete an entity from the specified store.
     """
 
-    def __init__(self, backend_name: str):
+    def __init__(self):
         """
         Initialize the `SQLiteBackend` instance, setting up the store mappings and tables.
-
-        Args:
-            backend_name (str): The name of the backend (e.g., "sqlite").
         """
         stores = {
             "study": SQLiteStudyStore(),
@@ -72,7 +69,7 @@ class SQLiteBackend(ResultsBackend):
             "physical_worker": SQLitePhysicalWorkerStore(),
         }
 
-        super().__init__(backend_name, stores)
+        super().__init__("sqlite", stores)
 
         # Initialize database schema
         self._initialize_schema()

--- a/merlin/cli/commands/status.py
+++ b/merlin/cli/commands/status.py
@@ -248,7 +248,7 @@ class DetailedStatusCommand(StatusCommand):
         status_display_group.add_argument(
             "--layout",
             type=str,
-            choices=status_renderer_factory.get_layouts(),
+            choices=status_renderer_factory.list_available(),
             default="default",
             help="Alternate status layouts [Default: %(default)s]",
         )

--- a/merlin/db_scripts/merlin_db.py
+++ b/merlin/db_scripts/merlin_db.py
@@ -59,7 +59,7 @@ class MerlinDatabase:
         """
         from merlin.config.configfile import CONFIG  # pylint: disable=import-outside-toplevel
 
-        self.backend: ResultsBackend = backend_factory.get_backend(CONFIG.results_backend.name.lower())
+        self.backend: ResultsBackend = backend_factory.create(CONFIG.results_backend.name.lower())
         self._entity_managers: Dict[str, EntityManager] = {
             "study": StudyManager(self.backend),
             "run": RunManager(self.backend),

--- a/merlin/display.py
+++ b/merlin/display.py
@@ -309,7 +309,8 @@ def display_status_task_by_task(status_obj: "DetailedStatus", test_mode: bool = 
     """
     args = status_obj.args
     try:
-        status_renderer = status_renderer_factory.get_renderer(args.layout, args.disable_theme, args.disable_pager)
+        renderer_config = {"disable_theme": args.disable_theme, "disable_pager": args.disable_pager}
+        status_renderer = status_renderer_factory.create(args.layout, config=renderer_config)
     except ValueError:
         LOG.error(f"Layout '{args.layout}' not implemented.")
         raise

--- a/merlin/exceptions/__init__.py
+++ b/merlin/exceptions/__init__.py
@@ -99,6 +99,15 @@ class BackendNotSupportedError(Exception):
         super().__init__(message)
 
 
+class MerlinInvalidStatusRendererError(Exception):
+    """
+    Exception to signal that an invalid status renderer was provided.
+    """
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
 ###############################
 # Database-Related Exceptions #
 ###############################

--- a/merlin/monitor/monitor.py
+++ b/merlin/monitor/monitor.py
@@ -74,7 +74,7 @@ class Monitor:
         self.spec: MerlinSpec = spec
         self.sleep: int = sleep
         self.no_restart: bool = no_restart
-        self.task_server_monitor: TaskServerMonitor = monitor_factory.get_monitor(task_server)
+        self.task_server_monitor: TaskServerMonitor = monitor_factory.create(task_server)
         self.merlin_db = MerlinDatabase()
 
     def monitor_all_runs(self):

--- a/merlin/monitor/monitor_factory.py
+++ b/merlin/monitor/monitor_factory.py
@@ -16,6 +16,7 @@ from merlin.exceptions import MerlinInvalidTaskServerError
 from merlin.monitor.celery_monitor import CeleryMonitor
 from merlin.monitor.task_server_monitor import TaskServerMonitor
 
+
 class MonitorFactory(MerlinBaseFactory):
     """
     Factory class for managing and instantiating Merlin task server monitors.
@@ -69,7 +70,7 @@ class MonitorFactory(MerlinBaseFactory):
             The entry point namespace for Merlin monitor plugins.
         """
         return "merlin.monitor"
-    
+
     def _get_component_error_class(self) -> type[Exception]:
         """
         Return the exception type to raise for unsupported components.

--- a/merlin/monitor/monitor_factory.py
+++ b/merlin/monitor/monitor_factory.py
@@ -16,65 +16,30 @@ from merlin.exceptions import MerlinInvalidTaskServerError
 from merlin.monitor.celery_monitor import CeleryMonitor
 from merlin.monitor.task_server_monitor import TaskServerMonitor
 
-
-# class MonitorFactory:
-#     """
-#     A factory class for managing and retrieving task server monitors
-#     for supported task servers in Merlin.
-
-#     Attributes:
-#         _monitors (Dict[str, TaskServerMonitor]): A dictionary mapping task server names
-#             to their corresponding monitor classes.
-
-#     Methods:
-#         get_supported_task_servers: Get a list of the supported task servers in Merlin.
-#         get_monitor: Get the monitor instance for the specified task server.
-#     """
-
-#     def __init__(self):
-#         """
-#         Initialize the `MonitorFactory` with the supported task server monitors.
-#         """
-#         self._monitors: Dict[str, TaskServerMonitor] = {
-#             "celery": CeleryMonitor,
-#         }
-
-#     def get_supported_task_servers(self) -> List[str]:
-#         """
-#         Get a list of the supported task servers in Merlin.
-
-#         Returns:
-#             A list of names representing the supported task servers in Merlin.
-#         """
-#         return list(self._monitors.keys())
-
-#     def get_monitor(self, task_server: str) -> TaskServerMonitor:
-#         """
-#         Get the task server monitor for whichever task server the user is utilizing.
-
-#         Args:
-#             task_server: The name of the task server to use when loading a task server monitor.
-
-#         Returns:
-#             An instantiated [`TaskServerMonitor`][monitor.task_server_monitor.TaskServerMonitor]
-#                 object for the specified task server.
-
-#         Raises:
-#             MerlinInvalidTaskServerError: If the requested task server is not supported.
-#         """
-#         monitor_object = self._monitors.get(task_server, None)
-
-#         if monitor_object is None:
-#             raise MerlinInvalidTaskServerError(
-#                 f"Task server unsupported by Merlin: {task_server}. "
-#                 "Supported task servers are: {self.get_supported_task_servers()}"
-#             )
-
-#         return monitor_object()
-
 class MonitorFactory(MerlinBaseFactory):
     """
-    
+    Factory class for managing and instantiating Merlin task server monitors.
+
+    This subclass of `MerlinBaseFactory` is responsible for registering,
+    validating, and creating instances of supported `TaskServerMonitor`
+    implementations (e.g., `CeleryMonitor`). It also supports plugin-based
+    extension via Python entry points.
+
+    Responsibilities:
+        - Register built-in task server monitors.
+        - Validate that components conform to the `TaskServerMonitor` interface.
+        - Support creation and introspection of registered monitor types.
+        - Optionally discover external monitor plugins.
+
+    Attributes:
+        _registry (Dict[str, TaskServerMonitor]): Maps canonical task server names to monitor classes.
+        _aliases (Dict[str, str]): Maps aliases to canonical monitor names.
+
+    Methods:
+        register: Register a new monitor class and optional aliases.
+        list_available: Return a list of supported monitor names.
+        create: Instantiate a monitor class by name or alias.
+        get_component_info: Return metadata about a registered monitor.
     """
 
     def _register_builtins(self):

--- a/merlin/monitor/monitor_factory.py
+++ b/merlin/monitor/monitor_factory.py
@@ -9,67 +9,114 @@ This module provides a factory class to manage and retrieve task server monitors
 for supported task servers in Merlin.
 """
 
-from typing import Dict, List
+from typing import Any
 
+from merlin.abstracts import MerlinBaseFactory
 from merlin.exceptions import MerlinInvalidTaskServerError
 from merlin.monitor.celery_monitor import CeleryMonitor
 from merlin.monitor.task_server_monitor import TaskServerMonitor
 
 
-class MonitorFactory:
+# class MonitorFactory:
+#     """
+#     A factory class for managing and retrieving task server monitors
+#     for supported task servers in Merlin.
+
+#     Attributes:
+#         _monitors (Dict[str, TaskServerMonitor]): A dictionary mapping task server names
+#             to their corresponding monitor classes.
+
+#     Methods:
+#         get_supported_task_servers: Get a list of the supported task servers in Merlin.
+#         get_monitor: Get the monitor instance for the specified task server.
+#     """
+
+#     def __init__(self):
+#         """
+#         Initialize the `MonitorFactory` with the supported task server monitors.
+#         """
+#         self._monitors: Dict[str, TaskServerMonitor] = {
+#             "celery": CeleryMonitor,
+#         }
+
+#     def get_supported_task_servers(self) -> List[str]:
+#         """
+#         Get a list of the supported task servers in Merlin.
+
+#         Returns:
+#             A list of names representing the supported task servers in Merlin.
+#         """
+#         return list(self._monitors.keys())
+
+#     def get_monitor(self, task_server: str) -> TaskServerMonitor:
+#         """
+#         Get the task server monitor for whichever task server the user is utilizing.
+
+#         Args:
+#             task_server: The name of the task server to use when loading a task server monitor.
+
+#         Returns:
+#             An instantiated [`TaskServerMonitor`][monitor.task_server_monitor.TaskServerMonitor]
+#                 object for the specified task server.
+
+#         Raises:
+#             MerlinInvalidTaskServerError: If the requested task server is not supported.
+#         """
+#         monitor_object = self._monitors.get(task_server, None)
+
+#         if monitor_object is None:
+#             raise MerlinInvalidTaskServerError(
+#                 f"Task server unsupported by Merlin: {task_server}. "
+#                 "Supported task servers are: {self.get_supported_task_servers()}"
+#             )
+
+#         return monitor_object()
+
+class MonitorFactory(MerlinBaseFactory):
     """
-    A factory class for managing and retrieving task server monitors
-    for supported task servers in Merlin.
-
-    Attributes:
-        _monitors (Dict[str, TaskServerMonitor]): A dictionary mapping task server names
-            to their corresponding monitor classes.
-
-    Methods:
-        get_supported_task_servers: Get a list of the supported task servers in Merlin.
-        get_monitor: Get the monitor instance for the specified task server.
+    
     """
 
-    def __init__(self):
+    def _register_builtins(self):
         """
-        Initialize the `MonitorFactory` with the supported task server monitors.
+        Register built-in monitor implementations.
         """
-        self._monitors: Dict[str, TaskServerMonitor] = {
-            "celery": CeleryMonitor,
-        }
+        self.register("celery", CeleryMonitor)
 
-    def get_supported_task_servers(self) -> List[str]:
+    def _validate_component(self, component_class: Any):
         """
-        Get a list of the supported task servers in Merlin.
-
-        Returns:
-            A list of names representing the supported task servers in Merlin.
-        """
-        return list(self._monitors.keys())
-
-    def get_monitor(self, task_server: str) -> TaskServerMonitor:
-        """
-        Get the task server monitor for whichever task server the user is utilizing.
+        Ensure registered component is a subclass of TaskServerMonitor.
 
         Args:
-            task_server: The name of the task server to use when loading a task server monitor.
-
-        Returns:
-            An instantiated [`TaskServerMonitor`][monitor.task_server_monitor.TaskServerMonitor]
-                object for the specified task server.
+            component_class: The class to validate.
 
         Raises:
-            MerlinInvalidTaskServerError: If the requested task server is not supported.
+            TypeError: If the component does not subclass TaskServerMonitor.
         """
-        monitor_object = self._monitors.get(task_server, None)
+        if not issubclass(component_class, TaskServerMonitor):
+            raise TypeError(f"{component_class} must inherit from TaskServerMonitor")
 
-        if monitor_object is None:
-            raise MerlinInvalidTaskServerError(
-                f"Task server unsupported by Merlin: {task_server}. "
-                "Supported task servers are: {self.get_supported_task_servers()}"
-            )
+    def _entry_point_group(self) -> str:
+        """
+        Entry point group used for discovering monitor plugins.
 
-        return monitor_object()
+        Returns:
+            The entry point namespace for Merlin monitor plugins.
+        """
+        return "merlin.monitor"
+    
+    def _get_component_error_class(self) -> type[Exception]:
+        """
+        Return the exception type to raise for unsupported components.
+
+        This method is used by the base factory logic to determine which
+        exception to raise when a requested component is not found or fails
+        to initialize.
+
+        Returns:
+            The exception class to raise.
+        """
+        return MerlinInvalidTaskServerError
 
 
 monitor_factory = MonitorFactory()

--- a/merlin/study/status.py
+++ b/merlin/study/status.py
@@ -1221,7 +1221,8 @@ class DetailedStatus(Status):
         }
 
         # Display the filter options
-        filter_option_renderer = status_renderer_factory.get_renderer("table", disable_theme=True, disable_pager=True)
+        renderer_config = {"disable_theme": True, "disable_pager": True} 
+        filter_option_renderer = status_renderer_factory.create("table", config=renderer_config)
         filter_option_renderer.layout(status_data=filter_info)
         filter_option_renderer.render()
 

--- a/merlin/study/status.py
+++ b/merlin/study/status.py
@@ -1221,7 +1221,7 @@ class DetailedStatus(Status):
         }
 
         # Display the filter options
-        renderer_config = {"disable_theme": True, "disable_pager": True} 
+        renderer_config = {"disable_theme": True, "disable_pager": True}
         filter_option_renderer = status_renderer_factory.create("table", config=renderer_config)
         filter_option_renderer.layout(status_data=filter_info)
         filter_option_renderer.render()

--- a/merlin/study/status_renderers.py
+++ b/merlin/study/status_renderers.py
@@ -456,7 +456,7 @@ class MerlinStatusRendererFactory(MerlinBaseFactory):
             The entry point namespace for Merlin status renderer plugins.
         """
         return "merlin.study"  # TODO change this to merlin.status when we refactor status
-    
+
     def _get_component_error_class(self) -> type[Exception]:
         """
         Return the exception type to raise for unsupported components.
@@ -469,7 +469,6 @@ class MerlinStatusRendererFactory(MerlinBaseFactory):
             The exception class to raise.
         """
         return MerlinInvalidStatusRendererError
-
 
 
 status_renderer_factory = MerlinStatusRendererFactory()

--- a/merlin/study/status_renderers.py
+++ b/merlin/study/status_renderers.py
@@ -6,9 +6,9 @@
 
 """This module handles creating a formatted task-by-task status display"""
 import logging
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
-from maestrowf import BaseStatusRenderer, FlatStatusRenderer, StatusRendererFactory
+from maestrowf import BaseStatusRenderer, FlatStatusRenderer
 from rich import box
 from rich.columns import Columns
 from rich.console import Console
@@ -16,6 +16,8 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 
+from merlin.abstracts import MerlinBaseFactory
+from merlin.exceptions import MerlinInvalidStatusRendererError
 from merlin.study.status_constants import NON_WORKSPACE_KEYS
 
 
@@ -71,9 +73,6 @@ class MerlinDefaultRenderer(BaseStatusRenderer):
                 - disable_pager (bool, optional): If `True`, disables pager functionality for the display. Defaults to `False`.
         """
         super().__init__(*args, **kwargs)
-
-        self.disable_theme: bool = kwargs.pop("disable_theme", False)
-        self.disable_pager: bool = kwargs.pop("disable_pager", False)
 
         # Setup default theme
         # TODO modify this theme to add more colors
@@ -319,41 +318,6 @@ class MerlinDefaultRenderer(BaseStatusRenderer):
             # Add this step to the full status table
             self._status_table.add_row(step_table, end_section=True)
 
-    def render(self, theme: Dict[str, str] = None):
-        """
-        Do the actual printing of the status table.
-
-        This method is responsible for rendering the status table to the console, applying any specified
-        theme settings for visual customization. It handles the enabling or disabling of themes and
-        manages the output display, either using a pager for long outputs or printing directly to the console.
-
-        Args:
-            theme: A dictionary of theme settings that define the appearance of the output. The keys and
-                values should correspond to the layout defined in `self._theme_dict`.
-        """
-        # Apply any theme customization
-        if theme:
-            LOG.debug(f"Applying theme: {theme}")
-            for key, value in theme.items():
-                self._theme_dict[key] = value
-
-        # If we're disabling the theme, we need to set all themes in the theme dict to none
-        if self.disable_theme:
-            LOG.debug("Disabling theme.")
-            for key in self._theme_dict:
-                self._theme_dict[key] = "none"
-
-        # Get the rich Console
-        status_theme = Theme(self._theme_dict)
-        _printer = Console(theme=status_theme)
-
-        # Display the status table
-        if self.disable_pager:
-            _printer.print(self._status_table)
-        else:
-            with _printer.pager(styles=(not self.disable_theme)):
-                _printer.print(self._status_table)
-
 
 class MerlinFlatRenderer(FlatStatusRenderer):
     """
@@ -370,11 +334,6 @@ class MerlinFlatRenderer(FlatStatusRenderer):
         render: Renders the status table to the console, applying any specified theme settings and
             managing the output display.
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(args, kwargs)
-        self.disable_theme: bool = kwargs.pop("disable_theme", False)
-        self.disable_pager: bool = kwargs.pop("disable_pager", False)
 
     def layout(self, status_data: Dict[str, List[Union[str, int]]], study_title: str = None):  # pylint: disable=W0221
         """
@@ -443,65 +402,74 @@ class MerlinFlatRenderer(FlatStatusRenderer):
                 _printer.print(self._status_table)
 
 
-class MerlinStatusRendererFactory(StatusRendererFactory):
+class MerlinStatusRendererFactory(MerlinBaseFactory):
     """
-    This class keeps track of all available status layouts for Merlin.
+    Factory class for managing and instantiating Merlin status renderers.
 
-    The `MerlinStatusRendererFactory` is responsible for managing different
-    status layout renderers used in the Merlin application. It provides a
-    method to retrieve the appropriate renderer based on the specified layout
-    type and user preferences regarding theme and pager usage.
+    This subclass of `MerlinBaseFactory` is responsible for registering,
+    validating, and creating instances of supported `BaseStatusRenderer`
+    implementations (e.g., `MerlinFlatRenderer`, `MerlinDefaultRenderer`).
+    It also supports dynamic discovery of plugins via Python entry points.
+
+    Responsibilities:
+        - Register built-in status renderer implementations.
+        - Validate that all components subclass `BaseStatusRenderer`.
+        - Provide a unified interface for instantiating renderers by name or alias.
+        - Optionally support discovery of external plugins.
 
     Attributes:
-        _layouts (Dict[str, BaseStatusRenderer]): A dictionary mapping layout names to their corresponding renderer
-            classes. Currently includes "table" for
-            [`MerlinFlatRenderer`][study.status_renderers.MerlinFlatRenderer] and
-            "default" for [`MerlinDefaultRenderer`][study.status_renderers.MerlinDefaultRenderer].
+        _registry (Dict[str, BaseStatusRenderer]): Maps canonical names to renderer classes.
+        _aliases (Dict[str, str]): Maps alternate names to canonical names.
 
     Methods:
-        get_renderer: Retrieves an instance of the specified layout renderer, applying
-            user preferences for theme and pager settings.
+        register: Register a renderer class and optional aliases.
+        list_available: Return a list of supported renderers.
+        create: Instantiate a renderer by name or alias.
+        get_component_info: Return metadata about a registered renderer.
     """
 
-    # TODO: when maestro releases the pager changes:
-    # - remove init and render in MerlinFlatRenderer
-    # - remove the get_renderer method below
-    # - remove self.disable_theme and self.disable_pager from MerlinFlatRenderer and MerlinDefaultRenderer
-    #   - these variables will be in BaseStatusRenderer in Maestro
-    # - remove render method in MerlinDefaultRenderer
-    #   - this will also be in BaseStatusRenderer in Maestro
-    def __init__(self):  # pylint: disable=W0231
-        self._layouts: Dict[str, BaseStatusRenderer] = {
-            "table": MerlinFlatRenderer,
-            "default": MerlinDefaultRenderer,
-        }
-
-    def get_renderer(
-        self, layout: str, disable_theme: bool, disable_pager: bool
-    ) -> BaseStatusRenderer:  # pylint: disable=W0221
+    def _register_builtins(self):
         """
-        Get handle for specific layout renderer to instantiate.
+        Register built-in status renderer implementations.
+        """
+        self.register("table", MerlinFlatRenderer)
+        self.register("default", MerlinDefaultRenderer)
+
+    def _validate_component(self, component_class: Any):
+        """
+        Ensure registered component is a subclass of BaseStatusRenderer.
 
         Args:
-            layout: A string denoting the name of the layout renderer to use.
-            disable_theme: True if the user wants to disable themes when displaying
-                status; False otherwise.
-            disable_pager: True if the user wants to disable the pager when displaying
-                status; False otherwise.
-
-        Returns:
-            The status renderer class to use for displaying the output.
+            component_class: The class to validate.
 
         Raises:
-            ValueError: If the specified layout is not found in the available layouts.
+            TypeError: If the component does not subclass BaseStatusRenderer.
         """
-        renderer = self._layouts.get(layout)
+        if not issubclass(component_class, BaseStatusRenderer):
+            raise TypeError(f"{component_class} must inherit from BaseStatusRenderer")
 
-        # Note, need to wrap renderer in try/catch too, or return default val?
-        if not renderer:
-            raise ValueError(layout)
+    def _entry_point_group(self) -> str:
+        """
+        Entry point group used for discovering status renderer plugins.
 
-        return renderer(disable_theme=disable_theme, disable_pager=disable_pager)
+        Returns:
+            The entry point namespace for Merlin status renderer plugins.
+        """
+        return "merlin.study"  # TODO change this to merlin.status when we refactor status
+    
+    def _get_component_error_class(self) -> type[Exception]:
+        """
+        Return the exception type to raise for unsupported components.
+
+        This method is used by the base factory logic to determine which
+        exception to raise when a requested component is not found or fails
+        to initialize.
+
+        Returns:
+            The exception class to raise.
+        """
+        return MerlinInvalidStatusRendererError
+
 
 
 status_renderer_factory = MerlinStatusRendererFactory()

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -2,7 +2,7 @@ cached_property
 celery[redis,sqlalchemy]>=5.0.3
 coloredlogs
 cryptography
-maestrowf>=1.1.9dev1
+maestrowf>=1.1.10
 numpy
 parse
 psutil>=5.1.0

--- a/tests/unit/abstracts/test_factory.py
+++ b/tests/unit/abstracts/test_factory.py
@@ -1,0 +1,176 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other Merlin
+# Project developers. See top-level LICENSE and COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Merlin.
+##############################################################################
+
+"""
+Tests for the `factory.py` module of the `abstracts/` directory.
+"""
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from merlin.abstracts import MerlinBaseFactory
+
+# --- Dummy Components ---
+class DummyComponent:
+    """A testable dummy component."""
+
+
+class DummyComponentWithInit:
+    def __init__(self, foo=None, bar=None):
+        self.foo = foo
+        self.bar = bar
+
+
+# --- Concrete Subclass for Testing ---
+class TestableFactory(MerlinBaseFactory):
+    def _register_builtins(self) -> None:
+        self.register("dummy", DummyComponent, aliases=["alias_dummy"])
+
+    def _validate_component(self, component_class: Any) -> None:
+        if not isinstance(component_class, type):
+            raise TypeError("Component must be a class")
+
+    def _entry_point_group(self) -> str:
+        return "merlin.test_plugins"
+
+    def _get_component_error_class(self) -> type[Exception]:
+        return RuntimeError  # Use a distinct error type for test verification
+
+
+class TestMerlinBaseFactory:
+    """
+    Unit test suite for the `MerlinBaseFactory` abstract base class.
+
+    This suite verifies the expected behavior of the factory's core logic through a
+    concrete subclass (`TestableFactory`) that defines the required abstract methods.
+    The tests ensure that the factory:
+
+    - Registers components and their aliases correctly
+    - Validates component classes during registration
+    - Creates instances with and without initialization arguments
+    - Resolves aliases when creating components
+    - Raises appropriate errors for unknown components
+    - Provides accurate component metadata through introspection
+    - Invokes plugin discovery hooks properly
+
+    The tests do not rely on external entry points or plugins, and use simple
+    dummy component classes to isolate and validate base functionality.
+    """
+
+    @pytest.fixture
+    def factory(self) -> TestableFactory:
+        """
+        An instance of the dummy `TestableFactory` class. Resets on each test.
+
+        Returns:
+            An instance of the dummy `TestableFactory` class for testing.
+        """
+        return TestableFactory()
+
+    def test_register_and_list(self, factory: TestableFactory):
+        """
+        Test that components are registered and listed properly.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        assert "dummy" in factory.list_available()
+        assert factory._registry["dummy"] is DummyComponent
+        assert factory._aliases["alias_dummy"] == "dummy"
+
+    def test_create_component_without_config(self, factory: TestableFactory):
+        """
+        Test instantiation of a registered component with no config.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        instance = factory.create("dummy")
+        assert isinstance(instance, DummyComponent)
+
+    def test_create_component_with_config(self, factory: TestableFactory):
+        """
+        Test instantiation of a component with constructor args.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        factory.register("with_init", DummyComponentWithInit)
+        config = {"foo": "a", "bar": 42}
+        instance = factory.create("with_init", config=config)
+        assert isinstance(instance, DummyComponentWithInit)
+        assert instance.foo == "a"
+        assert instance.bar == 42
+
+    def test_create_component_using_alias(self, factory: TestableFactory):
+        """
+        Test alias resolution in component creation.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        instance = factory.create("alias_dummy")
+        assert isinstance(instance, DummyComponent)
+
+    def test_create_unregistered_component_raises(self, factory: TestableFactory):
+        """
+        Test that creating an unknown component raises the correct error.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        with pytest.raises(RuntimeError, match="not supported"):
+            factory.create("unknown")
+
+    def test_register_invalid_component_raises(self, factory: TestableFactory):
+        """
+        Test that register raises TypeError for non-class input.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        with pytest.raises(TypeError):
+            factory.register("bad", object())  # not a class
+
+    def test_get_component_info(self, factory: TestableFactory):
+        """
+        Test metadata returned from `get_component_info`.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        info = factory.get_component_info("dummy")
+        assert info["name"] == "dummy"
+        assert info["class"] == "DummyComponent"
+        assert info["module"] == DummyComponent.__module__
+        assert "description" in info
+
+    def test_get_component_info_for_invalid_component(self, factory: TestableFactory):
+        """
+        Test that get_component_info raises when the component is unknown.
+
+        Args:
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        with pytest.raises(ValueError, match="not supported"):
+            factory.get_component_info("not_registered")
+
+    def test_discover_plugins_calls_both_hooks(self, mocker: MockerFixture, factory: TestableFactory):
+        """
+        Test that _discover_plugins calls both plugin and module hooks.
+
+        Args:
+            mocker: PyTest mocker fixture.
+            factory: An instance of the dummy `TestableFactory` class for testing.
+        """
+        plugin_mock = mocker.patch.object(factory, "_discover_plugins_via_entry_points")
+        builtin_mock = mocker.patch.object(factory, "_discover_builtin_modules")
+
+        factory._discover_plugins()
+        plugin_mock.assert_called_once()
+        builtin_mock.assert_called_once()

--- a/tests/unit/abstracts/test_factory.py
+++ b/tests/unit/abstracts/test_factory.py
@@ -15,6 +15,7 @@ from pytest_mock import MockerFixture
 
 from merlin.abstracts import MerlinBaseFactory
 
+
 # --- Dummy Components ---
 class DummyComponent:
     """A testable dummy component."""
@@ -157,7 +158,7 @@ class TestMerlinBaseFactory:
         Args:
             factory: An instance of the dummy `TestableFactory` class for testing.
         """
-        with pytest.raises(RuntimeError, match="not supported"):  # raises RuntimeError because of `_get_component_error_class` 
+        with pytest.raises(RuntimeError, match="not supported"):  # raises RuntimeError because of `_get_component_error_class`
             factory.get_component_info("not_registered")
 
     def test_discover_plugins_calls_both_hooks(self, mocker: MockerFixture, factory: TestableFactory):

--- a/tests/unit/abstracts/test_factory.py
+++ b/tests/unit/abstracts/test_factory.py
@@ -157,7 +157,7 @@ class TestMerlinBaseFactory:
         Args:
             factory: An instance of the dummy `TestableFactory` class for testing.
         """
-        with pytest.raises(ValueError, match="not supported"):
+        with pytest.raises(RuntimeError, match="not supported"):  # raises RuntimeError because of `_get_component_error_class` 
             factory.get_component_info("not_registered")
 
     def test_discover_plugins_calls_both_hooks(self, mocker: MockerFixture, factory: TestableFactory):

--- a/tests/unit/backends/redis/test_redis_backend.py
+++ b/tests/unit/backends/redis/test_redis_backend.py
@@ -81,7 +81,7 @@ def redis_backend_instance(
     mocker.patch("merlin.config.results_backend.get_connection_string", return_value=redis_backend_connection_string)
 
     # Initialize RedisBackend
-    backend = RedisBackend("redis")
+    backend = RedisBackend()
 
     # Override the client and stores with mocked objects
     backend.client = redis_backend_mock_redis_client

--- a/tests/unit/backends/sqlite/test_sqlite_backend.py
+++ b/tests/unit/backends/sqlite/test_sqlite_backend.py
@@ -34,7 +34,7 @@ def sqlite_backend_instance(mocker: MockerFixture) -> SQLiteBackend:
     # Patch the initialization method to avoid real DB operations
     mocker.patch.object(SQLiteBackend, "_initialize_schema", return_value=None)
 
-    backend = SQLiteBackend("sqlite")
+    backend = SQLiteBackend()
     return backend
 
 

--- a/tests/unit/backends/test_backend_factory.py
+++ b/tests/unit/backends/test_backend_factory.py
@@ -9,78 +9,85 @@ Tests for the `backend_factory.py` module.
 """
 
 import pytest
-from pytest_mock import MockerFixture
 
-from merlin.backends.backend_factory import backend_factory
+from merlin.backends.backend_factory import MerlinBackendFactory
 from merlin.backends.redis.redis_backend import RedisBackend
+from merlin.backends.results_backend import ResultsBackend
+from merlin.backends.sqlite.sqlite_backend import SQLiteBackend
 from merlin.exceptions import BackendNotSupportedError
 
 
-class TestBackendFactory:
+class TestMerlinBackendFactory:
     """
-    Test suite for the `backend_factory` module.
+    Test suite for the `MerlinBackendFactory`.
 
-    This class contains unit tests to validate the functionality of the `backend_factory`, which is responsible
-    for managing backend instances and providing an interface for retrieving supported backends and resolving
-    backend aliases.
-
-    Fixtures and mocking are used to isolate the tests from the actual backend implementations, ensuring that
-    the tests focus on the behavior of the `backend_factory` module.
-
-    These tests ensure the robustness and correctness of the `backend_factory` module, which is critical for
-    backend management in the Merlin framework.
+    This class tests that the backend factory correctly registers, resolves, instantiates,
+    and reports supported Merlin backends. It uses mocking to isolate backend behavior
+    and focuses on the factory's interface and logic.
     """
 
-    def test_get_supported_backends(self):
+    @pytest.fixture
+    def backend_factory(self) -> MerlinBackendFactory:
         """
-        Test that `get_supported_backends` returns the correct list of supported backends.
-        """
-        supported_backends = backend_factory.get_supported_backends()
-        assert supported_backends == ["redis", "sqlite"]
+        An instance of the `MerlinBackendFactory` class. Resets on each test.
 
-    def test_get_backend_with_valid_backend(self, mocker: MockerFixture):
+        Returns:
+            An instance of the `MerlinBackendFactory` class for testing.
         """
-        Test that `get_backend` returns the correct backend instance for a valid backend.
+        return MerlinBackendFactory()
+
+    def test_list_available_backends(self, backend_factory: MerlinBackendFactory):
+        """
+        Test that `list_available` returns the correct set of built-in backends.
 
         Args:
-            mocker (MockerFixture): A built-in fixture from the pytest-mock library to create a Mock object.
+            backend_factory: An instance of the `MerlinBackendFactory` class for testing.
         """
-        backend_name = "redis"
+        available = backend_factory.list_available()
+        assert set(available) == {"redis", "sqlite"}
 
-        # Mock the RedisBackend class to avoid instantiation issues
-        RedisBackendMock = mocker.MagicMock(spec=RedisBackend)
-        backend_factory._backends["redis"] = RedisBackendMock
-
-        backend_instance = backend_factory.get_backend(backend_name)
-
-        # Verify the backend instance is created correctly
-        RedisBackendMock.assert_called_once_with(backend_name)
-        assert backend_instance == RedisBackendMock(backend_name), "Backend instance should match the mocked backend."
-
-    def test_get_backend_with_alias(self, mocker: MockerFixture):
+    @pytest.mark.parametrize("backend_type, expected_cls", [("redis", RedisBackend), ("sqlite", SQLiteBackend)])
+    def test_create_valid_backend(self, backend_factory: MerlinBackendFactory, backend_type: str, expected_cls: ResultsBackend):
         """
-        Test that `get_backend` correctly resolves aliases to canonical backend names.
+        Test that `create` returns a valid backend instance for a registered name.
 
         Args:
-            mocker (MockerFixture): A built-in fixture from the pytest-mock library to create a Mock object.
+            backend_factory: An instance of the `MerlinBackendFactory` class for testing.
+            backend_type: The type of backend to create.
+            expected_cls: The class that we're expecting `backend_factory` to create.
         """
-        alias_name = "rediss"
+        instance = backend_factory.create(backend_type)
+        assert isinstance(instance, expected_cls)
 
-        # Mock the RedisBackend class to avoid instantiation issues
-        RedisBackendMock = mocker.MagicMock(spec=RedisBackend)
-        backend_factory._backends["redis"] = RedisBackendMock
-
-        backend_instance = backend_factory.get_backend(alias_name)
-
-        # Verify the alias resolves and the backend instance is created correctly
-        RedisBackendMock.assert_called_once_with("redis")
-        assert backend_instance == RedisBackendMock("redis"), "Backend instance should match the mocked backend."
-
-    def test_get_backend_with_invalid_backend(self):
+    def test_create_valid_backend_with_alias(self, backend_factory: MerlinBackendFactory):
         """
-        Test that get_backend raises BackendNotSupportedError for an unsupported backend.
-        """
-        invalid_backend_name = "unsupported_backend"
+        Test that aliases (e.g. 'rediss') are resolved to canonical backend names.
 
-        with pytest.raises(BackendNotSupportedError, match=f"Backend unsupported by Merlin: {invalid_backend_name}."):
-            backend_factory.get_backend(invalid_backend_name)
+        Args:
+            backend_factory: An instance of the `MerlinBackendFactory` class for testing.
+        """
+        instance = backend_factory.create("rediss")
+        assert isinstance(instance, RedisBackend)
+
+    def test_create_invalid_backend_raises(self, backend_factory: MerlinBackendFactory):
+        """
+        Test that `create` raises `BackendNotSupportedError` for unknown backends.
+
+        Args:
+            backend_factory: An instance of the `MerlinBackendFactory` class for testing.
+        """
+        with pytest.raises(BackendNotSupportedError, match="unsupported_backend"):
+            backend_factory.create("unsupported_backend")
+
+    def test_invalid_registration_type_error(self, backend_factory: MerlinBackendFactory):
+        """
+        Test that trying to register a non-ResultsBackend raises TypeError.
+
+        Args:
+            backend_factory: An instance of the `MerlinBackendFactory` class for testing.
+        """
+        class NotAResultsBackend:
+            pass
+
+        with pytest.raises(TypeError, match="must inherit from ResultsBackend"):
+            backend_factory.register("fake", NotAResultsBackend)

--- a/tests/unit/backends/test_backend_factory.py
+++ b/tests/unit/backends/test_backend_factory.py
@@ -47,7 +47,9 @@ class TestMerlinBackendFactory:
         assert set(available) == {"redis", "sqlite"}
 
     @pytest.mark.parametrize("backend_type, expected_cls", [("redis", RedisBackend), ("sqlite", SQLiteBackend)])
-    def test_create_valid_backend(self, backend_factory: MerlinBackendFactory, backend_type: str, expected_cls: ResultsBackend):
+    def test_create_valid_backend(
+        self, backend_factory: MerlinBackendFactory, backend_type: str, expected_cls: ResultsBackend
+    ):
         """
         Test that `create` returns a valid backend instance for a registered name.
 
@@ -86,6 +88,7 @@ class TestMerlinBackendFactory:
         Args:
             backend_factory: An instance of the `MerlinBackendFactory` class for testing.
         """
+
         class NotAResultsBackend:
             pass
 

--- a/tests/unit/db_scripts/test_merlin_db.py
+++ b/tests/unit/db_scripts/test_merlin_db.py
@@ -97,7 +97,7 @@ def mock_merlin_db(
             patch("merlin.db_scripts.merlin_db.PhysicalWorkerManager", return_value=mock_entity_managers["physical_worker"])
         )
 
-        mock_factory.get_backend.return_value = mock_backend
+        mock_factory.create.return_value = mock_backend
         db = MerlinDatabase()
 
         # Replace backend and entity managers with mocks
@@ -135,14 +135,14 @@ class TestMerlinDatabase:
             mock_config = stack.enter_context(patch("merlin.config.configfile.CONFIG"))
 
             # Configure mocks
-            mock_factory.get_backend.return_value = mock_backend
+            mock_factory.create.return_value = mock_backend
             mock_config.results_backend.name = "redis"
 
             # Create instances
             db = MerlinDatabase()
 
             # Verify backend was created
-            mock_factory.get_backend.assert_called_once_with("redis")
+            mock_factory.create.assert_called_once_with("redis")
 
             # Verify entity managers were created with the backend
             mock_study_manager.assert_called_once_with(mock_backend)

--- a/tests/unit/monitor/test_monitor_factory.py
+++ b/tests/unit/monitor/test_monitor_factory.py
@@ -15,49 +15,136 @@ from merlin.monitor.celery_monitor import CeleryMonitor
 from merlin.monitor.monitor_factory import MonitorFactory
 
 
-@pytest.fixture
-def factory() -> MonitorFactory:
+# @pytest.fixture
+# def factory() -> MonitorFactory:
+#     """
+#     Fixture to provide a `MonitorFactory` instance.
+
+#     Returns:
+#         An instance of the `MonitorFactory` object.
+#     """
+#     return MonitorFactory()
+
+
+# def test_get_supported_task_servers(factory: MonitorFactory):
+#     """
+#     Test that the correct list of supported task servers is returned.
+
+#     Args:
+#         factory: An instance of the `MonitorFactory` object.
+#     """
+#     supported = factory.get_supported_task_servers()
+#     assert isinstance(supported, list)
+#     assert "celery" in supported
+#     assert len(supported) == 1
+
+
+# def test_get_monitor_valid(factory: MonitorFactory):
+#     """
+#     Test that get_monitor returns the correct monitor for a valid task server.
+
+#     Args:
+#         factory: An instance of the `MonitorFactory` object.
+#     """
+#     monitor = factory.get_monitor("celery")
+#     assert isinstance(monitor, CeleryMonitor)
+
+
+# def test_get_monitor_invalid(factory: MonitorFactory):
+#     """
+#     Test that get_monitor raises an error for an unsupported task server.
+
+#     Args:
+#         factory: An instance of the `MonitorFactory` object.
+#     """
+#     with pytest.raises(MerlinInvalidTaskServerError) as excinfo:
+#         factory.get_monitor("invalid")
+
+#     assert "Task server unsupported by Merlin: invalid" in str(excinfo.value)
+
+
+class TestMonitorFactory:
     """
-    Fixture to provide a `MonitorFactory` instance.
+    Test suite for the `MonitorFactory`.
 
-    Returns:
-        An instance of the `MonitorFactory` object.
+    This class validates that the factory properly registers and instantiates
+    task server monitor classes (like `CeleryMonitor`), resolves component names,
+    and raises appropriate errors for unsupported types. These tests focus
+    on the behavior of the generic factory logic applied to monitor components.
     """
-    return MonitorFactory()
 
+    @pytest.fixture
+    def monitor_factory(self) -> MonitorFactory:
+        """
+        Create a fresh `MonitorFactory` instance for each test.
 
-def test_get_supported_task_servers(factory: MonitorFactory):
-    """
-    Test that the correct list of supported task servers is returned.
+        Returns:
+            A new instance of `MonitorFactory`.
+        """
+        return MonitorFactory()
 
-    Args:
-        factory: An instance of the `MonitorFactory` object.
-    """
-    supported = factory.get_supported_task_servers()
-    assert isinstance(supported, list)
-    assert "celery" in supported
-    assert len(supported) == 1
+    def test_list_available_monitors(self, monitor_factory: MonitorFactory):
+        """
+        Test that `list_available` returns registered task server monitors.
 
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        available = monitor_factory.list_available()
+        assert "celery" in available
+        assert len(available) == 1
 
-def test_get_monitor_valid(factory: MonitorFactory):
-    """
-    Test that get_monitor returns the correct monitor for a valid task server.
+    def test_create_valid_monitor(self, monitor_factory: MonitorFactory):
+        """
+        Test that `create` instantiates a monitor for a valid task server.
 
-    Args:
-        factory: An instance of the `MonitorFactory` object.
-    """
-    monitor = factory.get_monitor("celery")
-    assert isinstance(monitor, CeleryMonitor)
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        monitor = monitor_factory.create("celery")
+        assert isinstance(monitor, CeleryMonitor)
 
+    def test_create_invalid_monitor_raises(self, monitor_factory: MonitorFactory):
+        """
+        Test that creating a monitor for an unknown task server raises error.
 
-def test_get_monitor_invalid(factory: MonitorFactory):
-    """
-    Test that get_monitor raises an error for an unsupported task server.
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        with pytest.raises(MerlinInvalidTaskServerError, match="not supported"):
+            monitor_factory.create("invalid_task_server")
 
-    Args:
-        factory: An instance of the `MonitorFactory` object.
-    """
-    with pytest.raises(MerlinInvalidTaskServerError) as excinfo:
-        factory.get_monitor("invalid")
+    def test_register_invalid_component_type(self, monitor_factory: MonitorFactory):
+        """
+        Test that registering a non-TaskServerMonitor subclass raises TypeError.
 
-    assert "Task server unsupported by Merlin: invalid" in str(excinfo.value)
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        class NotAMonitor:
+            pass
+
+        with pytest.raises(TypeError, match="must inherit from TaskServerMonitor"):
+            monitor_factory.register("invalid", NotAMonitor)
+
+    def test_get_component_info_returns_expected_metadata(self, monitor_factory: MonitorFactory):
+        """
+        Test that `get_component_info` returns metadata about a monitor class.
+
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        info = monitor_factory.get_component_info("celery")
+        assert info["name"] == "celery"
+        assert info["class"] == "CeleryMonitor"
+        assert "description" in info
+
+    def test_get_component_info_for_unknown_component_raises(self, monitor_factory: MonitorFactory):
+        """
+        Test that `get_component_info` raises for unknown component types.
+
+        Args:
+            monitor_factory: Instance of `MonitorFactory` for testing.
+        """
+        with pytest.raises(MerlinInvalidTaskServerError, match="not supported"):
+            monitor_factory.get_component_info("unknown")

--- a/tests/unit/monitor/test_monitor_factory.py
+++ b/tests/unit/monitor/test_monitor_factory.py
@@ -121,6 +121,7 @@ class TestMonitorFactory:
         Args:
             monitor_factory: Instance of `MonitorFactory` for testing.
         """
+
         class NotAMonitor:
             pass
 

--- a/tests/unit/study/test_status_renderer_factory.py
+++ b/tests/unit/study/test_status_renderer_factory.py
@@ -40,11 +40,16 @@ class TestMerlinStatusRendererFactory:
         available = renderer_factory.list_available()
         assert set(available) == {"default", "table"}
 
-    @pytest.mark.parametrize("renderer_type, expected_cls", [
-        ("default", MerlinDefaultRenderer),
-        ("table", MerlinFlatRenderer),
-    ])
-    def test_create_valid_renderer(self, renderer_factory: MerlinStatusRendererFactory, renderer_type: str, expected_cls: BaseStatusRenderer):
+    @pytest.mark.parametrize(
+        "renderer_type, expected_cls",
+        [
+            ("default", MerlinDefaultRenderer),
+            ("table", MerlinFlatRenderer),
+        ],
+    )
+    def test_create_valid_renderer(
+        self, renderer_factory: MerlinStatusRendererFactory, renderer_type: str, expected_cls: BaseStatusRenderer
+    ):
         """
         Test that `create` returns the correct renderer instance for each type.
         """
@@ -62,6 +67,7 @@ class TestMerlinStatusRendererFactory:
         """
         Test that trying to register a non-renderer raises a TypeError.
         """
+
         class NotARenderer:
             pass
 

--- a/tests/unit/study/test_status_renderer_factory.py
+++ b/tests/unit/study/test_status_renderer_factory.py
@@ -1,0 +1,69 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other Merlin
+# Project developers. See top-level LICENSE and COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Merlin.
+##############################################################################
+
+"""
+Tests for the `MerlinStatusRendererFactory` class in the `status_renderers.py` module.
+"""
+
+import pytest
+from maestrowf import BaseStatusRenderer
+
+from merlin.exceptions import MerlinInvalidStatusRendererError
+from merlin.study.status_renderers import MerlinDefaultRenderer, MerlinFlatRenderer, MerlinStatusRendererFactory
+
+
+class TestMerlinStatusRendererFactory:
+    """
+    Test suite for the `MerlinStatusRendererFactory`.
+
+    This class verifies that the factory correctly registers, resolves, instantiates,
+    and reports status renderer components for the Merlin workflow framework.
+    """
+
+    @pytest.fixture
+    def renderer_factory(self) -> MerlinStatusRendererFactory:
+        """
+        An instance of the `MerlinStatusRendererFactory` class. Resets on each test.
+
+        Returns:
+            A fresh instance of the renderer factory.
+        """
+        return MerlinStatusRendererFactory()
+
+    def test_list_available_renderers(self, renderer_factory: MerlinStatusRendererFactory):
+        """
+        Test that `list_available` returns the correct built-in renderers.
+        """
+        available = renderer_factory.list_available()
+        assert set(available) == {"default", "table"}
+
+    @pytest.mark.parametrize("renderer_type, expected_cls", [
+        ("default", MerlinDefaultRenderer),
+        ("table", MerlinFlatRenderer),
+    ])
+    def test_create_valid_renderer(self, renderer_factory: MerlinStatusRendererFactory, renderer_type: str, expected_cls: BaseStatusRenderer):
+        """
+        Test that `create` returns the correct renderer instance for each type.
+        """
+        instance = renderer_factory.create(renderer_type)
+        assert isinstance(instance, expected_cls)
+
+    def test_create_invalid_renderer_raises(self, renderer_factory: MerlinStatusRendererFactory):
+        """
+        Test that `create` raises an error for an unrecognized renderer name.
+        """
+        with pytest.raises(MerlinInvalidStatusRendererError, match="not supported"):
+            renderer_factory.create("unsupported_renderer")
+
+    def test_invalid_registration_raises_type_error(self, renderer_factory: MerlinStatusRendererFactory):
+        """
+        Test that trying to register a non-renderer raises a TypeError.
+        """
+        class NotARenderer:
+            pass
+
+        with pytest.raises(TypeError, match="must inherit from BaseStatusRenderer"):
+            renderer_factory.register("fake", NotARenderer)


### PR DESCRIPTION
This PR refactors Merlin's factory classes so that they share common logic in a base class. This base class introduces the ability for plugins to be added for any component that inherits from it. The factories updated in this are:

- `MerlinBackendFactory`
- `MonitorFactory`
- `MerlinStatusRendererFactory`

The plugin addition goes hand-in-hand with the `TaskServerInterface` project that my summer intern Marcus Hsieh is working on (see #520).

I'm hoping these changes give a more structured approach to Merlin's codebase going forward.