### PR TITLE
bugfix/retry-on-store-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A page in the docs explaining the `feature_demo` example
 - Unit tests for the `spec/` folder
 - Batch block now supports placeholder entries
+- Automatic task retry for Celery's `BackendStoreError`
 
 ### Changed
 - The `merlin config` command:

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -21,12 +21,8 @@ from typing import Any, Callable, Dict, List, Optional
 # Need to disable an overwrite warning here since celery has an exception that we need that directly
 # overwrites a python built-in exception
 from celery import Signature, Task, chain, chord, group, shared_task, signature
-from celery.exceptions import (
-    BackendStoreError,
-    MaxRetriesExceededError,
-    OperationalError,
-    TimeoutError,  # pylint: disable=redefined-builtin
-)
+from celery.exceptions import TimeoutError  # pylint: disable=redefined-builtin
+from celery.exceptions import BackendStoreError, MaxRetriesExceededError, OperationalError
 from celery.result import AsyncResult
 from filelock import FileLock, Timeout
 from redis.exceptions import TimeoutError as RedisTimeoutError

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Dict, List, Optional
 # Need to disable an overwrite warning here since celery has an exception that we need that directly
 # overwrites a python built-in exception
 from celery import Signature, Task, chain, chord, group, shared_task, signature
-from celery.exceptions import MaxRetriesExceededError, OperationalError, TimeoutError  # pylint: disable=W0622
+from celery.exceptions import BackendStoreError, MaxRetriesExceededError, OperationalError, TimeoutError  # pylint: disable=W0622
 from celery.result import AsyncResult
 from filelock import FileLock, Timeout
 from redis.exceptions import TimeoutError as RedisTimeoutError
@@ -50,6 +50,7 @@ retry_exceptions = (
     RestartException,
     FileNotFoundError,
     RedisTimeoutError,
+    BackendStoreError,
 )
 
 LOG = logging.getLogger(__name__)

--- a/merlin/common/tasks.py
+++ b/merlin/common/tasks.py
@@ -21,7 +21,12 @@ from typing import Any, Callable, Dict, List, Optional
 # Need to disable an overwrite warning here since celery has an exception that we need that directly
 # overwrites a python built-in exception
 from celery import Signature, Task, chain, chord, group, shared_task, signature
-from celery.exceptions import BackendStoreError, MaxRetriesExceededError, OperationalError, TimeoutError  # pylint: disable=W0622
+from celery.exceptions import (
+    BackendStoreError,
+    MaxRetriesExceededError,
+    OperationalError,
+    TimeoutError,  # pylint: disable=redefined-builtin
+)
 from celery.result import AsyncResult
 from filelock import FileLock, Timeout
 from redis.exceptions import TimeoutError as RedisTimeoutError


### PR DESCRIPTION
When Celery's BackendStoreError is raised the task should be auto-retried and shouldn't cause a failure.