### PR TITLE
Bugfix/workspace-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Potential security vulnerabilities related to logging
 - Bug where the `--task-status` and `--return-code` filters of `merlin detailed-status` only accepted filters in all caps
 - Bug where absolute path was required in the broker password field
+- Bug where potential studies list was not alphabetically sorted when running `merlin status <yaml>`
 
 ## [1.12.2]
 ### Added

--- a/merlin/study/status.py
+++ b/merlin/study/status.py
@@ -297,14 +297,16 @@ class Status:
         # Build a list of potential study output directories
         study_output_subdirs = next(os.walk(study_output_dir))[1]
         timestamp_regex = r"\d{8}-\d{6}"
-        potential_studies = []
-        num_studies = 0
         LOG.debug(f"All subdirs in output path: {study_output_subdirs}")
-        for subdir in study_output_subdirs:
-            match = re.search(rf"{self.args.spec_provided.name}_{timestamp_regex}", subdir)
-            if match:
-                potential_studies.append((num_studies + 1, subdir))
-                num_studies += 1
+        matches = [  # Collect matching subdirs first
+            subdir for subdir in study_output_subdirs
+            if re.search(rf"{self.args.spec_provided.name}_{timestamp_regex}", subdir)
+        ]
+        matches.sort()  # Sort alphabetically
+
+        # Rebuild potential_studies with sorted order and new indices
+        potential_studies = [(i + 1, subdir) for i, subdir in enumerate(matches)]
+        num_studies = len(potential_studies)
         LOG.debug(f"Potential studies: {potential_studies}")
 
         # Obtain the correct study to view the status of based on the list of potential studies we just built

--- a/merlin/study/status.py
+++ b/merlin/study/status.py
@@ -299,7 +299,8 @@ class Status:
         timestamp_regex = r"\d{8}-\d{6}"
         LOG.debug(f"All subdirs in output path: {study_output_subdirs}")
         matches = [  # Collect matching subdirs first
-            subdir for subdir in study_output_subdirs
+            subdir
+            for subdir in study_output_subdirs
             if re.search(rf"{self.args.spec_provided.name}_{timestamp_regex}", subdir)
         ]
         matches.sort()  # Sort alphabetically


### PR DESCRIPTION
Made the potential study list output alphabetical in the `merlin status <yaml>` command. This was requested by John Goforth.