### PR TITLE
bugfix/tcsh-worker-launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Bug where the worker launch using tcsh shell wasn't working
+
 ## [2.0.0b1]
 
 ### Added

--- a/merlin/workers/celery_worker.py
+++ b/merlin/workers/celery_worker.py
@@ -134,7 +134,7 @@ class CeleryWorker(MerlinWorker):
         self._verify_args(disable_logs=disable_logs)
 
         # Construct the launch command
-        celery_cmd = f"celery -A merlin worker {self.args} -Q {','.join(self.queues)}"
+        celery_cmd = f"celery -A merlin worker {self.args} -Q '{','.join(self.queues)}'"
         nodes = self.batch.get("nodes", None)
         launch_cmd = batch_worker_launch(self.batch, celery_cmd, nodes=nodes)
         return os.path.expandvars(launch_cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import sys
 from copy import copy
 from glob import glob
 from time import sleep
+from typing import Dict
 
 import pytest
 import yaml
@@ -321,6 +322,51 @@ def test_encryption_key() -> FixtureBytes:
     :returns: The test encryption key
     """
     return b"Q3vLp07Ljm60ahfU9HwOOnfgGY91lSrUmqcTiP0v9i0="
+
+
+@pytest.fixture
+def base_study_config() -> FixtureDict:
+    """
+    Base study configuration that can be modified for different shell tests.
+
+    Returns:
+        A dictionary containing base information for running a Merlin study.
+    """
+    return {
+        "description": {"name": "shell_test_study", "description": "Test study for shell compatibility"},
+        "batch": {
+            "shell": "/bin/bash",
+        },
+        "study": [
+            {"name": "test_step", "description": "Simple test step", "run": {"cmd": 'echo "Hello from $(basename $SHELL)"'}}
+        ],
+        "merlin": {
+            "resources": {
+                "workers": {
+                    "test_worker": {"args": "-l INFO --concurrency 1 --prefetch-multiplier 1 -O fair", "steps": ["all"]}
+                }
+            }
+        },
+    }
+
+
+@pytest.fixture
+def create_spec_file():
+    """
+    Factory fixture to create YAML spec files for testing.
+
+    Returns:
+        A function to create a spec file.
+    """
+
+    def _create_spec_file(config: Dict, output_dir: str, file_name: str):
+        file_path = os.path.join(output_dir, file_name)
+        with open(file_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
+
+        return file_path
+
+    return _create_spec_file
 
 
 #######################################

--- a/tests/integration/commands/test_run_workers.py
+++ b/tests/integration/commands/test_run_workers.py
@@ -1,0 +1,142 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other Merlin
+# Project developers. See top-level LICENSE and COPYRIGHT files for dates and
+# other details. No copyright assignment is required to contribute to Merlin.
+##############################################################################
+
+"""
+This module will contain the testing logic for the `merlin run-workers` command.
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from tests.fixture_data_classes import RedisBrokerAndBackend
+from tests.fixture_types import FixtureCallable, FixtureDict, FixtureStr
+from tests.integration.conditions import HasRegex, HasReturnCode
+from tests.integration.helper_funcs import check_test_conditions, copy_app_yaml_to_cwd
+
+
+@pytest.fixture(scope="session")
+def run_workers_command_testing_dir(create_testing_dir: FixtureCallable, temp_output_dir: FixtureStr) -> FixtureStr:
+    """
+    Fixture to create a temporary output directory for tests related to testing the
+    `merlin run-workers` functionality.
+
+    Args:
+        create_testing_dir: A fixture which returns a function that creates the testing directory.
+        temp_output_dir: The path to the temporary ouptut directory we'll be using for this test run.
+
+    Returns:
+        The path to the temporary testing directory for `merlin run-workers` tests.
+    """
+    return create_testing_dir(temp_output_dir, "run_command_testing")
+
+
+class TestRunWorkersCommand:
+    """
+    Base class for testing the `merlin run-workers` command.
+    """
+
+    def kill_worker_process(self, worker_process: subprocess.Popen):
+        """
+        Kill a given worker process.
+
+        This method will execute Merlin's stop-workers command to attempt to
+        shut down the Celery workers. Then it will try to gracefully terminate
+        the process that was running said workers.
+
+        Args:
+            worker_process: A subprocess where the workers are living
+        """
+        # Run merlin's stop-workers first
+        subprocess.run(["merlin", "stop-workers"])
+
+        # Manually terminate the process as well, just to be safe
+        worker_process.terminate()
+        try:
+            worker_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            worker_process.kill()
+            worker_process.wait()
+
+    @pytest.mark.parametrize(
+        "shell",
+        [
+            "/bin/bash",
+            "/bin/sh",
+            "/bin/tcsh",
+            "/bin/csh",
+            "/bin/zsh"
+        ],
+    )
+    def test_workers_start_for_different_shells(
+        self,
+        shell: str,
+        base_study_config: FixtureDict,
+        create_spec_file: FixtureCallable,
+        run_workers_command_testing_dir: FixtureStr,
+        redis_broker_and_backend_function: RedisBrokerAndBackend,
+        merlin_server_dir: FixtureStr,
+    ):
+        """
+        Test that workers spin up for different shells.
+
+        Args:
+            shell: The shell to test (parametrized)
+            base_study_config: Base study configuration fixture
+            create_study_file: Fixture to create study files
+            run_workers_command_testing_dir: Temp output directory for run-workers tests
+            redis_broker_and_backend_function: Fixture for setting up Redis broker and
+                backend for function-scoped tests.
+            merlin_server_dir:
+                A fixture to provide the path to the merlin_server directory that will be
+                created by the `redis_server` fixture.
+        """
+        # Skip test if shell is not available on the system
+        if not os.path.exists(shell):
+            pytest.skip(f"Shell {shell} not available on this system")
+
+        # Create study config for this shell
+        study_config = base_study_config.copy()
+        study_config["batch"]["shell"] = shell
+
+        # Create the spec file
+        spec_file = create_spec_file(study_config, run_workers_command_testing_dir, "test_workers_actually_start.yaml")
+
+        # Copy the app.yaml to the cwd so merlin will connect to the testing server
+        copy_app_yaml_to_cwd(merlin_server_dir)
+
+        try:
+            # Start the workers
+            worker_process = subprocess.Popen(
+                ["merlin", "run-workers", spec_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+
+            # Give the workers time to start
+            time.sleep(10)
+
+            # Ping the workers to see if they've started
+            ping_process = subprocess.run(["celery", "-A", "merlin", "inspect", "ping"], capture_output=True, text=True)
+
+            # Store information about the ping in a dict
+            info = {
+                "stdout": ping_process.stdout,
+                "stderr": ping_process.stderr,
+                "return_code": ping_process.returncode,
+            }
+
+            # Establish test conditions
+            conditions = [
+                HasReturnCode(),
+                HasRegex(r"celery@test_worker.*: OK"),
+            ]
+
+            # Check that all of the test conditions pass
+            check_test_conditions(conditions, info)
+        finally:
+            # Always clean up
+            self.kill_worker_process(worker_process)

--- a/tests/integration/definitions.py
+++ b/tests/integration/definitions.py
@@ -314,7 +314,7 @@ def define_tests():  # pylint: disable=R0914,R0915
         },
         "default_worker assigned": {
             "cmds": f"{workers} {test_specs}/default_worker_test.yaml --echo",
-            "conditions": [HasReturnCode(), HasRegex(r"default_worker.*-Q \[merlin\]_step_4_queue")],
+            "conditions": [HasReturnCode(), HasRegex(r"default_worker.*-Q '\[merlin\]_step_4_queue'")],
             "run type": "local",
         },
         "no default_worker assigned": {

--- a/tests/unit/workers/test_celery_worker.py
+++ b/tests/unit/workers/test_celery_worker.py
@@ -9,7 +9,7 @@ Tests for the `merlin/workers/celery_worker.py` module.
 """
 
 from typing import Any
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest_mock import MockerFixture
@@ -198,7 +198,7 @@ def test_get_launch_command_queues_wrapped_in_single_quotes(
 
     # Check that queues are wrapped in single quotes
     assert "-Q 'queue1,queue2'" in celery_cmd_arg
-    
+
     # Ensure no unquoted commas that would break tcsh parsing
     assert "-Q queue1,queue2" not in celery_cmd_arg
 

--- a/tests/unit/workers/test_celery_worker.py
+++ b/tests/unit/workers/test_celery_worker.py
@@ -9,7 +9,7 @@ Tests for the `merlin/workers/celery_worker.py` module.
 """
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -176,6 +176,31 @@ def test_get_launch_command_returns_expanded_command(
 
     assert isinstance(cmd, str)
     assert "celery" in cmd
+
+
+def test_get_launch_command_queues_wrapped_in_single_quotes(
+    mocker: MockerFixture,
+    basic_config: FixtureDict[str, Any],
+    dummy_env: FixtureDict[str, str],
+    mock_db: MagicMock,
+):
+    """Test that queue names are properly wrapped in single quotes."""
+    # This test assumes you have a way to create a worker instance from your study
+    # You'll need to adapt this to your actual class structure
+    mock_launch = mocker.patch("merlin.workers.celery_worker.batch_worker_launch")
+    worker = CeleryWorker("w2", basic_config, dummy_env)
+
+    worker.get_launch_command()
+
+    # Verify that batch_worker_launch was called with properly quoted queues
+    mock_launch.assert_called_once()
+    celery_cmd_arg = mock_launch.call_args[0][1]  # Second argument to batch_worker_launch
+
+    # Check that queues are wrapped in single quotes
+    assert "-Q 'queue1,queue2'" in celery_cmd_arg
+    
+    # Ensure no unquoted commas that would break tcsh parsing
+    assert "-Q queue1,queue2" not in celery_cmd_arg
 
 
 def test_should_launch_rejects_if_machine_check_fails(

--- a/tests/unit/workers/test_celery_worker.py
+++ b/tests/unit/workers/test_celery_worker.py
@@ -9,7 +9,7 @@ Tests for the `merlin/workers/celery_worker.py` module.
 """
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from pytest_mock import MockerFixture


### PR DESCRIPTION
Kelli Humbird found a bug with the new worker launch refactor that causes launching workers using tcsh type shells to fail. This PR fixes the issue and adds tests for checking that workers launch properly with different shells. The fix here is to wrap the list of queues that a worker watches in quotes.