### PR TITLE
hotfix/run-complete-bc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Merlin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0b4]
+
+### Added
+- Backwards compatibility for `run_complete` entries in the database
+
 ## [2.0.0b3]
 
 ### Added

--- a/merlin/__init__.py
+++ b/merlin/__init__.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 
-__version__ = "2.0.0b3"
+__version__ = "2.0.0b4"
 VERSION = __version__
 PATH_TO_PROJ = os.path.join(os.path.dirname(__file__), "")
 

--- a/merlin/backends/utils.py
+++ b/merlin/backends/utils.py
@@ -73,7 +73,7 @@ def serialize_entity(entity: T) -> Dict[str, str]:
     Returns:
         A dictionary of information that the database can interpret.
     """
-    LOG.debug("Deserializing data...")
+    LOG.debug("Serializing data...")
     serialized_data = {}
 
     for field in entity.get_instance_fields():
@@ -90,7 +90,7 @@ def serialize_entity(entity: T) -> Dict[str, str]:
         else:
             serialized_data[field.name] = str(field_value)
 
-    LOG.debug("Successfully deserialized data.")
+    LOG.debug("Successfully serialized data.")
     return serialized_data
 
 

--- a/merlin/db_scripts/data_models.py
+++ b/merlin/db_scripts/data_models.py
@@ -105,6 +105,15 @@ class BaseDataModel(ABC):
         Returns:
             An instance of the dataclass that called this.
         """
+        # Handle backwards compatibility between 2.0.0b2 and 2.0.0b3: migrate run_complete to run_status
+        if "run_complete" in data and "run_status" not in data:
+            run_complete = data.pop("run_complete")
+            # Map the boolean to an appropriate status
+            data["run_status"] = RunStatus.COMPLETED.value if run_complete else RunStatus.RUNNING.value
+        elif "run_complete" in data and "run_status" in data:
+            # Remove run_complete if both keys exist to avoid conflicts
+            data.pop("run_complete")
+
         return cls(**data)
 
     @classmethod

--- a/merlin/db_scripts/entities/run_entity.py
+++ b/merlin/db_scripts/entities/run_entity.py
@@ -217,25 +217,25 @@ class RunEntity(DatabaseEntity[RunModel], QueueManagementMixin):
             True if the run is in a terminal state (COMPLETED, CANCELLED, FAILED).
         """
         return self.get_run_status() in (RunStatus.COMPLETED, RunStatus.CANCELLED, RunStatus.FAILED)
-    
+
     @property
     def run_complete(self) -> bool:
         """
         Backwards compatibility property for old code/databases using run_complete.
-        
+
         Returns:
             True if the run has completed (successfully or otherwise), False otherwise.
-        
+
         Deprecated: Use run_status instead.
         """
         return self.is_finished()
-    
+
     @run_complete.setter
     def run_complete(self, value: bool):
         """
         Backwards compatibility setter for old code using run_complete.
         Maps boolean values to the appropriate run_status.
-        
+
         Deprecated: Use run_status instead.
         """
         if value:

--- a/merlin/db_scripts/entities/run_entity.py
+++ b/merlin/db_scripts/entities/run_entity.py
@@ -217,6 +217,37 @@ class RunEntity(DatabaseEntity[RunModel], QueueManagementMixin):
             True if the run is in a terminal state (COMPLETED, CANCELLED, FAILED).
         """
         return self.get_run_status() in (RunStatus.COMPLETED, RunStatus.CANCELLED, RunStatus.FAILED)
+    
+    @property
+    def run_complete(self) -> bool:
+        """
+        Backwards compatibility property for old code/databases using run_complete.
+        
+        Returns:
+            True if the run has completed (successfully or otherwise), False otherwise.
+        
+        Deprecated: Use run_status instead.
+        """
+        return self.is_finished()
+    
+    @run_complete.setter
+    def run_complete(self, value: bool):
+        """
+        Backwards compatibility setter for old code using run_complete.
+        Maps boolean values to the appropriate run_status.
+        
+        Deprecated: Use run_status instead.
+        """
+        if value:
+            # If setting to complete and current status is not already a terminal state,
+            # default to COMPLETED
+            if self.get_run_status() not in (RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED):
+                self.set_run_status(RunStatus.COMPLETED)
+        else:
+            # If setting to not complete, assume RUNNING
+            # (unless it's already in a terminal state, which would be odd)
+            if self.get_run_status() in (RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED):
+                self.set_run_status(RunStatus.RUNNING)
 
     def get_metadata_file(self) -> str:
         """


### PR DESCRIPTION
Adds backwards compatibility for code prior to 2.0.0b3 that still uses `run_complete`. The ICECap team has some workflows that they need to be able to restart but can't without this functionality.